### PR TITLE
[unit-tests] fix ci blockers

### DIFF
--- a/src/tests/UnitTests/Generator/ResetPasswordTokenGeneratorTest.php
+++ b/src/tests/UnitTests/Generator/ResetPasswordTokenGeneratorTest.php
@@ -28,7 +28,7 @@ class ResetPasswordTokenGeneratorTest extends TestCase
     /**
      * @inheritDoc
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->mockRandomGenerator = $this->createMock(ResetPasswordRandomGenerator::class);
         $this->mockExpiresAt = $this->createMock(\DateTimeImmutable::class);

--- a/src/tests/UnitTests/ResetPasswordHelperTest.php
+++ b/src/tests/UnitTests/ResetPasswordHelperTest.php
@@ -29,11 +29,6 @@ class ResetPasswordHelperTest extends TestCase
     private $mockTokenGenerator;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|ResetPasswordRandomGenerator
-     */
-    private $mockRandomGenerator;
-
-    /**
      * @var \PHPUnit\Framework\MockObject\MockObject|ResetPasswordRequestInterface
      */
     private $mockResetRequest;
@@ -55,7 +50,6 @@ class ResetPasswordHelperTest extends TestCase
     {
         $this->mockRepo = $this->createMock(ResetPasswordRequestRepositoryInterface::class);
         $this->mockTokenGenerator = $this->createMock(ResetPasswordTokenGenerator::class);
-        $this->mockRandomGenerator = $this->createMock(ResetPasswordRandomGenerator::class);
         $this->mockResetRequest = $this->createMock(ResetPasswordRequestInterface::class);
         $this->randomToken = \bin2hex(\random_bytes(10));
         $this->mockUser = new class {};
@@ -67,8 +61,7 @@ class ResetPasswordHelperTest extends TestCase
             $this->mockRepo,
             99999999,
             99999999,
-            $this->mockTokenGenerator,
-            $this->mockRandomGenerator
+            $this->mockTokenGenerator
         );
     }
 


### PR DESCRIPTION
`[unitTests] fixed missing setUp() return type required by phpunit 8`
fixes phpunit failure on actions CI and local phpunit runs

`[unit-tests] removed unused mock random generator`
the random generator was leftover from an earlier iteration of the bundle, and slipped through the cracks. No longer needed in the `ResetPasswordHelperTest::class`
