### PR TITLE
refactor token generator / unit test

### DIFF
--- a/src/Generator/ResetPasswordTokenGenerator.php
+++ b/src/Generator/ResetPasswordTokenGenerator.php
@@ -24,16 +24,10 @@ class ResetPasswordTokenGenerator
      */
     private $randomGenerator;
 
-    /**
-     * @var string Non-hashed token verification string
-     */
-    private $verifier;
-
     public function __construct(string $signingKey, ResetPasswordRandomGenerator $generator)
     {
         $this->signingKey = $signingKey;
         $this->randomGenerator = $generator;
-        $this->verifier = $this->randomGenerator->getRandomAlphaNumStr(self::RANDOM_STR_LENGTH);
     }
 
     /**
@@ -44,8 +38,8 @@ class ResetPasswordTokenGenerator
      */
     public function getToken(\DateTimeInterface $expiresAt, $userId, string $verifier = null): ResetPasswordTokenComponents
     {
-        if (empty($verifier)) {
-            $verifier = $this->verifier;
+        if (null === $verifier) {
+            $verifier = $this->randomGenerator->getRandomAlphaNumStr(self::RANDOM_STR_LENGTH);
         }
 
         $selector = $this->randomGenerator->getRandomAlphaNumStr(self::RANDOM_STR_LENGTH);

--- a/src/Generator/ResetPasswordTokenGenerator.php
+++ b/src/Generator/ResetPasswordTokenGenerator.php
@@ -36,7 +36,7 @@ class ResetPasswordTokenGenerator
      * @param mixed  $userId   Unique user identifier
      * @param string $verifier Only required for token comparison
      */
-    public function getToken(\DateTimeInterface $expiresAt, $userId, string $verifier = null): ResetPasswordTokenComponents
+    public function createToken(\DateTimeInterface $expiresAt, $userId, string $verifier = null): ResetPasswordTokenComponents
     {
         if (null === $verifier) {
             $verifier = $this->randomGenerator->getRandomAlphaNumStr(self::RANDOM_STR_LENGTH);

--- a/src/ResetPasswordHelper.php
+++ b/src/ResetPasswordHelper.php
@@ -65,7 +65,7 @@ class ResetPasswordHelper implements ResetPasswordHelperInterface
             ->modify(sprintf('+%d seconds', $this->resetRequestLifetime))
         ;
 
-        $tokenData = $this->tokenGenerator->getToken($expiresAt, $this->repository->getUserIdentifier($user));
+        $tokenData = $this->tokenGenerator->createToken($expiresAt, $this->repository->getUserIdentifier($user));
 
         $passwordResetRequest = $this->repository->createResetPasswordRequest(
             $user,
@@ -100,7 +100,7 @@ class ResetPasswordHelper implements ResetPasswordHelperInterface
 
         $user = $resetRequest->getUser();
 
-        $hashedVerifierToken = $this->tokenGenerator->getToken(
+        $hashedVerifierToken = $this->tokenGenerator->createToken(
             $resetRequest->getExpiresAt(),
             $this->repository->getUserIdentifier($user),
             substr($fullToken, self::SELECTOR_LENGTH)

--- a/src/tests/UnitTests/Generator/ResetPasswordTokenGeneratorTest.php
+++ b/src/tests/UnitTests/Generator/ResetPasswordTokenGeneratorTest.php
@@ -76,7 +76,7 @@ class ResetPasswordTokenGeneratorTest extends TestCase
         $knownVerifier = 'verified';
 
         $this->mockRandomGenerator
-            ->expects($this->exactly(1))
+            ->expects($this->once())
             ->method('getRandomAlphaNumStr')
             ->willReturnOnConsecutiveCalls('un-used-verifier', 'selector')
         ;

--- a/src/tests/UnitTests/Generator/ResetPasswordTokenGeneratorTest.php
+++ b/src/tests/UnitTests/Generator/ResetPasswordTokenGeneratorTest.php
@@ -51,7 +51,7 @@ class ResetPasswordTokenGeneratorTest extends TestCase
         ;
 
         $generator = $this->getTokenGenerator();
-        $generator->getToken($this->mockExpiresAt, 'userId');
+        $generator->createToken($this->mockExpiresAt, 'userId');
     }
 
     public function testHashedTokenIsCreatedWithExpectedParams(): void
@@ -75,7 +75,7 @@ class ResetPasswordTokenGeneratorTest extends TestCase
         );
 
         $generator = $this->getTokenGenerator();
-        $result = $generator->getToken($this->mockExpiresAt, 'user1234');
+        $result = $generator->createToken($this->mockExpiresAt, 'user1234');
 
         self::assertSame($expected, $result->getHashedToken());
     }
@@ -105,7 +105,7 @@ class ResetPasswordTokenGeneratorTest extends TestCase
         );
 
         $generator = $this->getTokenGenerator();
-        $result = $generator->getToken($this->mockExpiresAt, $userId, $knownVerifier);
+        $result = $generator->createToken($this->mockExpiresAt, $userId, $knownVerifier);
 
         self::assertSame($knownToken, $result->getHashedToken());
     }

--- a/src/tests/UnitTests/Generator/ResetPasswordTokenGeneratorTest.php
+++ b/src/tests/UnitTests/Generator/ResetPasswordTokenGeneratorTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
- * @author Ryan Weaver <weaverryan@gmail.com>
+ * @author Ryan Weaver <ryan@symfonycasts.com>
  */
 class ResetPasswordTokenGeneratorTest extends TestCase
 {

--- a/src/tests/UnitTests/Generator/ResetPasswordTokenGeneratorTest.php
+++ b/src/tests/UnitTests/Generator/ResetPasswordTokenGeneratorTest.php
@@ -12,9 +12,6 @@ use PHPUnit\Framework\TestCase;
  */
 class ResetPasswordTokenGeneratorTest extends TestCase
 {
-    private const RANDOM_STR_LENGTH = 20;
-    private const RANDOM_GENERATOR_METHOD_NAME = 'getRandomAlphaNumStr';
-
     /**
      * @var \PHPUnit\Framework\MockObject\MockObject|ResetPasswordRandomGenerator
      */
@@ -34,20 +31,12 @@ class ResetPasswordTokenGeneratorTest extends TestCase
         $this->mockExpiresAt = $this->createMock(\DateTimeImmutable::class);
     }
 
-    private function getTokenGenerator(): ResetPasswordTokenGenerator
-    {
-        return new ResetPasswordTokenGenerator(
-            'key',
-            $this->mockRandomGenerator
-        );
-    }
-
     public function testSelectorGeneratedByRandomGenerator(): void
     {
         $this->mockRandomGenerator
             ->expects($this->exactly(2))
-            ->method(self::RANDOM_GENERATOR_METHOD_NAME)
-            ->with(self::RANDOM_STR_LENGTH)
+            ->method('getRandomAlphaNumStr')
+            ->with(20)
         ;
 
         $generator = $this->getTokenGenerator();
@@ -58,7 +47,7 @@ class ResetPasswordTokenGeneratorTest extends TestCase
     {
         $this->mockRandomGenerator
             ->expects($this->exactly(2))
-            ->method(self::RANDOM_GENERATOR_METHOD_NAME)
+            ->method('getRandomAlphaNumStr')
             ->willReturnOnConsecutiveCalls('verifier', 'selector')
         ;
 
@@ -88,7 +77,7 @@ class ResetPasswordTokenGeneratorTest extends TestCase
 
         $this->mockRandomGenerator
             ->expects($this->exactly(1))
-            ->method(self::RANDOM_GENERATOR_METHOD_NAME)
+            ->method('getRandomAlphaNumStr')
             ->willReturnOnConsecutiveCalls('un-used-verifier', 'selector')
         ;
 
@@ -108,5 +97,13 @@ class ResetPasswordTokenGeneratorTest extends TestCase
         $result = $generator->createToken($this->mockExpiresAt, $userId, $knownVerifier);
 
         self::assertSame($knownToken, $result->getHashedToken());
+    }
+
+    private function getTokenGenerator(): ResetPasswordTokenGenerator
+    {
+        return new ResetPasswordTokenGenerator(
+            'key',
+            $this->mockRandomGenerator
+        );
     }
 }

--- a/src/tests/UnitTests/Generator/ResetPasswordTokenGeneratorTest.php
+++ b/src/tests/UnitTests/Generator/ResetPasswordTokenGeneratorTest.php
@@ -42,18 +42,6 @@ class ResetPasswordTokenGeneratorTest extends TestCase
         );
     }
 
-    public function testConstructorGetsVerifierFromRandomGenerator(): void
-    {
-        $this->mockRandomGenerator
-            ->expects($this->once())
-            ->method(self::RANDOM_GENERATOR_METHOD_NAME)
-            ->with(self::RANDOM_STR_LENGTH)
-            ->willReturn('rando-str')
-        ;
-
-        $this->getTokenGenerator();
-    }
-
     public function testSelectorGeneratedByRandomGenerator(): void
     {
         $this->mockRandomGenerator
@@ -99,7 +87,7 @@ class ResetPasswordTokenGeneratorTest extends TestCase
         $knownVerifier = 'verified';
 
         $this->mockRandomGenerator
-            ->expects($this->exactly(2))
+            ->expects($this->exactly(1))
             ->method(self::RANDOM_GENERATOR_METHOD_NAME)
             ->willReturnOnConsecutiveCalls('un-used-verifier', 'selector')
         ;


### PR DESCRIPTION
- fixed probably bug that would allow the reuse of a verifier token on subsequent `getToken()` method calls on the same generator instance.
- changed `getToken()` to `createToken()` to better reflect what the method is doing
- several minor improvement's to associated unit test

refs issue #3 
