### PR TITLE
fixed typo in token generator service argument

### DIFF
--- a/src/Resources/config/reset_password_services.xml
+++ b/src/Resources/config/reset_password_services.xml
@@ -7,7 +7,7 @@
     <services>
         <service id="symfonycasts.reset_password.random_generator" class="SymfonyCasts\Bundle\ResetPassword\Generator\ResetPasswordRandomGenerator" public="false" />
         <service id="symfonycasts.reset_password.token_generator" class="SymfonyCasts\Bundle\ResetPassword\Generator\ResetPasswordTokenGenerator" public="false">
-            <argument>%kernel.secret</argument>
+            <argument>%kernel.secret%</argument>
             <argument type="service" id="symfonycasts.reset_password.random_generator" />
         </service>
 


### PR DESCRIPTION
missing "%" in the kernel.secret argument