### PR TITLE
[RequestTrait] renamed constructor to avoid naming collisions

### DIFF
--- a/src/Model/ResetPasswordRequestTrait.php
+++ b/src/Model/ResetPasswordRequestTrait.php
@@ -6,7 +6,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
- * @author Ryan Weaver <weaverryan@gmail.com>
+ * @author Ryan Weaver <ryan@symfonycasts.com>
  */
 trait ResetPasswordRequestTrait
 {

--- a/src/Model/ResetPasswordRequestTrait.php
+++ b/src/Model/ResetPasswordRequestTrait.php
@@ -30,7 +30,7 @@ trait ResetPasswordRequestTrait
      */
     private $expiresAt;
 
-    public function __construct(\DateTimeInterface $expiresAt, string $selector, string $hashedToken)
+    private function initialize(\DateTimeInterface $expiresAt, string $selector, string $hashedToken)
     {
         $this->requestedAt = new \DateTimeImmutable('now');
         $this->expiresAt = $expiresAt;

--- a/src/tests/UnitTests/Model/ResetPasswordRequestTraitTest.php
+++ b/src/tests/UnitTests/Model/ResetPasswordRequestTraitTest.php
@@ -32,6 +32,11 @@ class ResetPasswordRequestTraitTest extends TestCase
         {
             use ResetPasswordRequestTrait;
 
+            public function __construct($expiresAt, $selector, $token)
+            {
+                $this->initialize($expiresAt, $selector, $token);
+            }
+
             /**
              * getUser() is intentionally left out of the trait.
              * it is created via maker under App\Entity\PasswordResetRequest


### PR DESCRIPTION
the consumer may already have a constructor in the request entity. renaming to initialize avoids funky use statements.