### PR TITLE
replace format with timestamp in token generation

### DIFF
--- a/src/Generator/ResetPasswordTokenGenerator.php
+++ b/src/Generator/ResetPasswordTokenGenerator.php
@@ -50,7 +50,7 @@ class ResetPasswordTokenGenerator
 
         $selector = $this->randomGenerator->getRandomAlphaNumStr(self::RANDOM_STR_LENGTH);
 
-        $encodedData = \json_encode([$verifier, $userId, $expiresAt->format('Y-m-d\TH:i:s')]);
+        $encodedData = \json_encode([$verifier, $userId, $expiresAt->getTimestamp()]);
 
         return new ResetPasswordTokenComponents(
             $selector,

--- a/src/tests/UnitTests/Generator/ResetPasswordTokenGeneratorTest.php
+++ b/src/tests/UnitTests/Generator/ResetPasswordTokenGeneratorTest.php
@@ -76,13 +76,13 @@ class ResetPasswordTokenGeneratorTest extends TestCase
 
         $this->mockExpiresAt
             ->expects($this->once())
-            ->method('format')
-            ->willReturn('2020')
+            ->method('getTimestamp')
+            ->willReturn(2020)
         ;
 
         $expected = \hash_hmac(
             'sha256',
-            \json_encode(['verifier', 'user1234', '2020']),
+            \json_encode(['verifier', 'user1234', 2020]),
             'key'
         );
 
@@ -94,7 +94,7 @@ class ResetPasswordTokenGeneratorTest extends TestCase
 
     public function testHashedTokenIsCreatedUsingOptionVerifierParam(): void
     {
-        $date = '2020';
+        $date = 2020;
         $userId = 'user1234';
         $knownVerifier = 'verified';
 
@@ -106,7 +106,7 @@ class ResetPasswordTokenGeneratorTest extends TestCase
 
         $this->mockExpiresAt
             ->expects($this->once())
-            ->method('format')
+            ->method('getTimestamp')
             ->willReturn($date)
         ;
 


### PR DESCRIPTION
tokens are one-way and not human readable, use a timestamp vs formatted data string for the encoded expiry time in generation

fixes #22 