### PR TITLE
Update bundle dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,9 @@
         "symfony/http-kernel": "^4.4 | ^5.0"
     },
     "require-dev": {
-        "doctrine/orm": "^3.0@dev",
+        "doctrine/orm": "^2.7",
         "friendsofphp/php-cs-fixer": "^2.16",
-        "symfony/http-foundation": "^5.0",
+        "symfony/framework-bundle": "^5.0",
         "symfony/phpunit-bridge": "^5.0",
         "vimeo/psalm": "^3.8"
     },

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,21 @@
 {
     "type": "symfony-bundle",
     "license": "MIT",
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "require": {
         "php": "^7.2",
-        "symfony/framework-bundle": "^4.4 | ^5.0"
+        "symfony/config": "^4.4 | ^5.0",
+        "symfony/dependency-injection": "^4.4 | ^5.0",
+        "symfony/http-kernel": "^4.4 | ^5.0"
     },
     "require-dev": {
+        "symfony/http-foundation": "^5.0",
         "symfony/phpunit-bridge": "^5.0",
         "vimeo/psalm": "^3.8"
+    },
+    "conflict": {
+        "symfony/http-foundation": "<4.4",
+        "symfony/framework-bundle": "<4.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,11 @@
     "require-dev": {
         "symfony/http-foundation": "^5.0",
         "symfony/phpunit-bridge": "^5.0",
-        "vimeo/psalm": "^3.8"
+        "vimeo/psalm": "^3.8",
+        "doctrine/orm": "^3.0@dev"
     },
     "conflict": {
+        "doctrine/orm": "<2.7",
         "symfony/http-foundation": "<4.4",
         "symfony/framework-bundle": "<4.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,11 @@
         "symfony/http-kernel": "^4.4 | ^5.0"
     },
     "require-dev": {
+        "doctrine/orm": "^3.0@dev",
+        "friendsofphp/php-cs-fixer": "^2.16",
         "symfony/http-foundation": "^5.0",
         "symfony/phpunit-bridge": "^5.0",
-        "vimeo/psalm": "^3.8",
-        "doctrine/orm": "^3.0@dev"
+        "vimeo/psalm": "^3.8"
     },
     "conflict": {
         "doctrine/orm": "<2.7",


### PR DESCRIPTION
- set dev minimum stability to allow development on latest packages
- replaced bloated framework-bundle dependency with components required by the bundle
- prevent use with older symfony versions by adding conflicts