### PR TITLE
add fake repository to allow symfony console on fresh install

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -67,5 +67,10 @@
                 <file name="src/DependencyInjection/SymfonyCastsResetPasswordExtension.php"/>
             </errorLevel>
         </PossiblyNullArgument>
+        <InvalidReturnType>
+            <errorLevel type="suppress">
+                <file name="src/Persistence/Fake/FakeResetPasswordInternalRepository.php"/>
+            </errorLevel>
+        </InvalidReturnType>
     </issueHandlers>
 </psalm>

--- a/src/Exception/FakeRepositoryException.php
+++ b/src/Exception/FakeRepositoryException.php
@@ -10,6 +10,6 @@ final class FakeRepositoryException extends \Exception implements ResetPasswordE
 {
     public function getReason(): string
     {
-        return 'Change repository signature for request_password_repository in config/packages/reset_password.yaml.';
+        return 'Please update the request_password_repository configuration in config/packages/reset_password.yaml to point to your "request password repository` service.';
     }
 }

--- a/src/Exception/FakeRepositoryException.php
+++ b/src/Exception/FakeRepositoryException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace SymfonyCasts\Bundle\ResetPassword\Exception;
+
+/**
+ * @author Jesse Rushlow <jr@rushlow.dev>
+ * @author Ryan Weaver   <ryan@symfonycasts.com>
+ */
+final class FakeRepositoryException extends \Exception implements ResetPasswordExceptionInterface
+{
+    public function getReason(): string
+    {
+        return 'Change repository signature for request_password_repository in config/packages/reset_password.yaml.';
+    }
+}

--- a/src/Persistence/Fake/FakeResetPasswordInternalRepository.php
+++ b/src/Persistence/Fake/FakeResetPasswordInternalRepository.php
@@ -6,7 +6,7 @@ use SymfonyCasts\Bundle\ResetPassword\Exception\FakeRepositoryException;
 use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordRequestInterface;
 use SymfonyCasts\Bundle\ResetPassword\Persistence\ResetPasswordRequestRepositoryInterface;
 
-@trigger_error('FakeResetPasswordInternalRepository is only a placeholder. It\'s signature should be replaced in config/packages/reset_password.yaml', E_USER_WARNING);
+@trigger_error('Please set a value for reset_request_repository in config/packages/reset_password.yaml', E_USER_WARNING);
 
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>

--- a/src/Persistence/Fake/FakeResetPasswordInternalRepository.php
+++ b/src/Persistence/Fake/FakeResetPasswordInternalRepository.php
@@ -6,9 +6,9 @@ use SymfonyCasts\Bundle\ResetPassword\Exception\FakeRepositoryException;
 use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordRequestInterface;
 use SymfonyCasts\Bundle\ResetPassword\Persistence\ResetPasswordRequestRepositoryInterface;
 
-@trigger_error('Please set a value for reset_request_repository in config/packages/reset_password.yaml', E_USER_WARNING);
-
 /**
+ * Class is only used as a placeholder and it's signature should be replaced in reset_password.yaml.
+ *
  * @author Jesse Rushlow <jr@rushlow.dev>
  * @author Ryan Weaver   <ryan@symfonycasts.com>
  *

--- a/src/Persistence/Fake/FakeResetPasswordInternalRepository.php
+++ b/src/Persistence/Fake/FakeResetPasswordInternalRepository.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace SymfonyCasts\Bundle\ResetPassword\Persistence\Fake;
+
+use SymfonyCasts\Bundle\ResetPassword\Exception\FakeRepositoryException;
+use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordRequestInterface;
+use SymfonyCasts\Bundle\ResetPassword\Persistence\ResetPasswordRequestRepositoryInterface;
+
+@trigger_error('FakeResetPasswordInternalRepository is only a placeholder. It\'s signature should be replaced in config/packages/reset_password.yaml', E_USER_WARNING);
+
+/**
+ * @author Jesse Rushlow <jr@rushlow.dev>
+ * @author Ryan Weaver   <ryan@symfonycasts.com>
+ *
+ * @internal
+ */
+final class FakeResetPasswordInternalRepository implements ResetPasswordRequestRepositoryInterface
+{
+    public function createResetPasswordRequest(object $user, \DateTimeInterface $expiresAt, string $selector, string $hashedToken): ResetPasswordRequestInterface
+    {
+        $this->throwException();
+    }
+
+    public function getUserIdentifier(object $user): string
+    {
+        $this->throwException();
+    }
+
+    public function persistResetPasswordRequest(ResetPasswordRequestInterface $resetPasswordRequest): void
+    {
+        $this->throwException();
+    }
+
+    public function findResetPasswordRequest(string $selector): ?ResetPasswordRequestInterface
+    {
+        $this->throwException();
+    }
+
+    public function getMostRecentNonExpiredRequestDate(object $user): ?\DateTimeInterface
+    {
+        $this->throwException();
+    }
+
+    public function removeResetPasswordRequest(ResetPasswordRequestInterface $resetPasswordRequest): void
+    {
+        $this->throwException();
+    }
+
+    public function removeExpiredResetPasswordRequests(): int
+    {
+        $this->throwException();
+    }
+
+    private function throwException(): void
+    {
+        throw new FakeRepositoryException();
+    }
+}

--- a/src/Persistence/Fake/FakeResetPasswordInternalRepository.php
+++ b/src/Persistence/Fake/FakeResetPasswordInternalRepository.php
@@ -7,7 +7,10 @@ use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordRequestInterface;
 use SymfonyCasts\Bundle\ResetPassword\Persistence\ResetPasswordRequestRepositoryInterface;
 
 /**
- * Class is only used as a placeholder and it's signature should be replaced in reset_password.yaml.
+ * Class is only used as a placeholder for the bundle configuration on new installs.
+ *
+ * The value of reset_request_repository should be changed to your
+ * request password repository service in reset_password.yaml.
  *
  * @author Jesse Rushlow <jr@rushlow.dev>
  * @author Ryan Weaver   <ryan@symfonycasts.com>
@@ -18,40 +21,35 @@ final class FakeResetPasswordInternalRepository implements ResetPasswordRequestR
 {
     public function createResetPasswordRequest(object $user, \DateTimeInterface $expiresAt, string $selector, string $hashedToken): ResetPasswordRequestInterface
     {
-        $this->throwException();
+        throw new FakeRepositoryException();
     }
 
     public function getUserIdentifier(object $user): string
     {
-        $this->throwException();
+        throw new FakeRepositoryException();
     }
 
     public function persistResetPasswordRequest(ResetPasswordRequestInterface $resetPasswordRequest): void
     {
-        $this->throwException();
+        throw new FakeRepositoryException();
     }
 
     public function findResetPasswordRequest(string $selector): ?ResetPasswordRequestInterface
     {
-        $this->throwException();
+        throw new FakeRepositoryException();
     }
 
     public function getMostRecentNonExpiredRequestDate(object $user): ?\DateTimeInterface
     {
-        $this->throwException();
+        throw new FakeRepositoryException();
     }
 
     public function removeResetPasswordRequest(ResetPasswordRequestInterface $resetPasswordRequest): void
     {
-        $this->throwException();
+        throw new FakeRepositoryException();
     }
 
     public function removeExpiredResetPasswordRequests(): int
-    {
-        $this->throwException();
-    }
-
-    private function throwException(): void
     {
         throw new FakeRepositoryException();
     }

--- a/src/Resources/config/reset_password_services.xml
+++ b/src/Resources/config/reset_password_services.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="symfonycasts.reset_password.fake_request_repository" class="SymfonyCasts\Bundle\ResetPassword\Persistence\FakeInternalRepository" public="false" lazy="true"/>
+        <service id="symfonycasts.reset_password.fake_request_repository" class="SymfonyCasts\Bundle\ResetPassword\Persistence\FakeInternalRepository" public="false"/>
         <service id="symfonycasts.reset_password.cleaner" class="SymfonyCasts\Bundle\ResetPassword\Util\ResetPasswordCleaner" public="false">
             <argument /> <!-- reset password request persister -->
             <argument /> <!-- reset password request enable_garbage_collection -->

--- a/src/Resources/config/reset_password_services.xml
+++ b/src/Resources/config/reset_password_services.xml
@@ -5,6 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <service id="symfonycasts.reset_password.fake_request_repository" class="SymfonyCasts\Bundle\ResetPassword\Persistence\FakeInternalRepository" public="false" lazy="true"/>
         <service id="symfonycasts.reset_password.cleaner" class="SymfonyCasts\Bundle\ResetPassword\Util\ResetPasswordCleaner" public="false">
             <argument /> <!-- reset password request persister -->
             <argument /> <!-- reset password request enable_garbage_collection -->

--- a/tests/UnitTests/Exception/ResetPasswordExceptionTest.php
+++ b/tests/UnitTests/Exception/ResetPasswordExceptionTest.php
@@ -4,12 +4,14 @@ namespace SymfonyCasts\Bundle\ResetPassword\Tests\UnitTests\Exception;
 
 use PHPUnit\Framework\TestCase;
 use SymfonyCasts\Bundle\ResetPassword\Exception\ExpiredResetPasswordTokenException;
+use SymfonyCasts\Bundle\ResetPassword\Exception\FakeRepositoryException;
 use SymfonyCasts\Bundle\ResetPassword\Exception\InvalidResetPasswordTokenException;
 use SymfonyCasts\Bundle\ResetPassword\Exception\ResetPasswordExceptionInterface;
 use SymfonyCasts\Bundle\ResetPassword\Exception\TooManyPasswordRequestsException;
 
 /**
- * @author  Jesse Rushlow <jr@geeshoe.com>
+ * @author Jesse Rushlow <jr@rushlow.dev>
+ * @author Ryan Weaver   <ryan@symfonycasts.com>
  */
 class ResetPasswordExceptionTest extends TestCase
 {
@@ -26,6 +28,10 @@ class ResetPasswordExceptionTest extends TestCase
         yield [
             TooManyPasswordRequestsException::class,
             'You have already requested a reset password email. Please check your email or try again soon.'
+        ];
+        yield [
+            FakeRepositoryException::class,
+            'Change repository signature for request_password_repository in config/packages/reset_password.yaml.'
         ];
     }
 

--- a/tests/UnitTests/Exception/ResetPasswordExceptionTest.php
+++ b/tests/UnitTests/Exception/ResetPasswordExceptionTest.php
@@ -31,7 +31,7 @@ class ResetPasswordExceptionTest extends TestCase
         ];
         yield [
             FakeRepositoryException::class,
-            'Change repository signature for request_password_repository in config/packages/reset_password.yaml.'
+            'Please update the request_password_repository configuration in config/packages/reset_password.yaml to point to your "request password repository` service.'
         ];
     }
 

--- a/tests/UnitTests/Persistence/FakeResetPasswordInternalRepositoryTest.php
+++ b/tests/UnitTests/Persistence/FakeResetPasswordInternalRepositoryTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace SymfonyCasts\Bundle\ResetPassword\Tests\UnitTests\Persistence;
+
+use SymfonyCasts\Bundle\ResetPassword\Exception\FakeRepositoryException;
+use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordRequestInterface;
+use SymfonyCasts\Bundle\ResetPassword\Persistence\Fake\FakeResetPasswordInternalRepository;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Jesse Rushlow <jr@rushlow.dev>
+ * @author Ryan Weaver   <ryan@symfonycasts.com>
+ */
+final class FakeResetPasswordInternalRepositoryTest extends TestCase
+{
+    public function methodDataProvider(): \Generator
+    {
+        yield ['createResetPasswordRequest', [new \stdClass(), new \DateTimeImmutable(), '', '']];
+        yield ['getUserIdentifier', [new \stdClass()]];
+        yield ['persistResetPasswordRequest', [$this->createMock(ResetPasswordRequestInterface::class)]];
+        yield ['findResetPasswordRequest', ['']];
+        yield ['getMostRecentNonExpiredRequestDate', [new \stdClass()]];
+        yield ['removeResetPasswordRequest', [$this->createMock(ResetPasswordRequestInterface::class)]];
+    }
+
+    /**
+     * @dataProvider methodDataProvider
+     */
+    public function testAllMethodsThrowFakeRepositoryException(string $methodName, array $params): void
+    {
+        $repo = new FakeResetPasswordInternalRepository();
+
+        $this->expectException(FakeRepositoryException::class);
+
+        $repo->$methodName(...$params);
+    }
+}


### PR DESCRIPTION
With a fresh install, the bundle blocks usage of the Symfony console until `request_password_repository` has been set with an actual instance of `ResetPasswordRequestRepositoryInterface`.  As using the console to create such a repository may be required, this PR introduces a fake repository that is the default place holder until a real repository can be created / set.

The solution to issue #47 will actually create the actual `reset_password.yaml` file.

fixes #46 