### PR TITLE
improve hashed token performence

### DIFF
--- a/src/Generator/ResetPasswordTokenGenerator.php
+++ b/src/Generator/ResetPasswordTokenGenerator.php
@@ -55,6 +55,6 @@ class ResetPasswordTokenGenerator
 
     private function getHashedToken(string $data): string
     {
-        return \hash_hmac('sha256', $data, $this->signingKey, false);
+        return \base64_encode(\hash_hmac('sha256', $data, $this->signingKey, true));
     }
 }

--- a/tests/UnitTests/Generator/ResetPasswordTokenGeneratorTest.php
+++ b/tests/UnitTests/Generator/ResetPasswordTokenGeneratorTest.php
@@ -60,13 +60,14 @@ class ResetPasswordTokenGeneratorTest extends TestCase
         $expected = \hash_hmac(
             'sha256',
             \json_encode(['verifier', 'user1234', 2020]),
-            'key'
+            'key',
+            true
         );
 
         $generator = $this->getTokenGenerator();
         $result = $generator->createToken($this->mockExpiresAt, 'user1234');
 
-        self::assertSame($expected, $result->getHashedToken());
+        self::assertSame(\base64_encode($expected), $result->getHashedToken());
     }
 
     public function testHashedTokenIsCreatedUsingOptionVerifierParam(): void
@@ -90,13 +91,14 @@ class ResetPasswordTokenGeneratorTest extends TestCase
         $knownToken = \hash_hmac(
             'sha256',
             \json_encode([$knownVerifier, $userId, $date]),
-            'key'
+            'key',
+            true
         );
 
         $generator = $this->getTokenGenerator();
         $result = $generator->createToken($this->mockExpiresAt, $userId, $knownVerifier);
 
-        self::assertSame($knownToken, $result->getHashedToken());
+        self::assertSame(\base64_encode($knownToken), $result->getHashedToken());
     }
 
     private function getTokenGenerator(): ResetPasswordTokenGenerator


### PR DESCRIPTION
We encode the binary output of `hash_hmac` using `base64_encode()` to reduce the string length of the token. Appx. 31% length reduction without compromising integrity.

```
$nativeHexit = $nativeHexit = \hash_hmac('sha256', 'data', 'key', false);
$base64 = \base64_encode(\hash_hmac('sha256', 'data', 'key', true));

self::assertSame(44, \strlen($base64)); // true
self::assertSame(64, \strlen($nativeHexit)); // true
```