### PR TITLE
moved psalm suppression to psalm config for consistency

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -70,6 +70,7 @@
         <InvalidReturnType>
             <errorLevel type="suppress">
                 <file name="src/Persistence/Fake/FakeResetPasswordInternalRepository.php"/>
+                <file name="src/Command/ResetPasswordRemoveExpiredCommand.php" />
             </errorLevel>
         </InvalidReturnType>
     </issueHandlers>

--- a/src/Command/ResetPasswordRemoveExpiredCommand.php
+++ b/src/Command/ResetPasswordRemoveExpiredCommand.php
@@ -41,8 +41,6 @@ class ResetPasswordRemoveExpiredCommand extends Command
 
     /**
      * {@inheritdoc}
-     *
-     * @psalm-suppress InvalidReturnType
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {


### PR DESCRIPTION
`ResetPasswordRemovedExpiredCommand::execute()` had a psalm suppression for `InvalidReturnType` in the method docBlock. Moved suppression to the psalm config as that is where all other suppression's are being declared.

closes #56 