### PR TITLE
minor refactoring of the tests suite

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,8 +15,17 @@
     </php>
 
     <testsuites>
-        <testsuite name="All-Tests">
+        <testsuite name="all">
             <directory>./tests</directory>
+        </testsuite>
+        <testsuite name="unit">
+            <directory>./tests/UnitTests</directory>
+        </testsuite>
+        <testsuite name="functional">
+            <directory>./tests/FunctionalTests</directory>
+        </testsuite>
+        <testsuite name="integration">
+            <directory>./tests/IntegratonTests</directory>
         </testsuite>
     </testsuites>
 

--- a/tests/UnitTests/Command/ResetPasswordRemoveExpiredCommandTest.php
+++ b/tests/UnitTests/Command/ResetPasswordRemoveExpiredCommandTest.php
@@ -9,10 +9,10 @@
 
 namespace SymfonyCasts\Bundle\ResetPassword\Tests\UnitTests\Command;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use SymfonyCasts\Bundle\ResetPassword\Command\ResetPasswordRemoveExpiredCommand;
-use PHPUnit\Framework\TestCase;
 use SymfonyCasts\Bundle\ResetPassword\Util\ResetPasswordCleaner;
 
 /**
@@ -39,8 +39,7 @@ class ResetPasswordRemoveExpiredCommandTest extends TestCase
 
     private function getCommandFixture($mockCleaner)
     {
-        return new class ($mockCleaner) extends ResetPasswordRemoveExpiredCommand
-        {
+        return new class($mockCleaner) extends ResetPasswordRemoveExpiredCommand {
             public function callExecute(InputInterface $input, OutputInterface $output): void
             {
                 $this->execute($input, $output);

--- a/tests/UnitTests/Controller/ResetPasswordControllerTraitTest.php
+++ b/tests/UnitTests/Controller/ResetPasswordControllerTraitTest.php
@@ -32,7 +32,7 @@ class ResetPasswordControllerTraitTest extends TestCase
     private $mockSession;
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected function setUp(): void
     {
@@ -135,8 +135,7 @@ class ResetPasswordControllerTraitTest extends TestCase
     {
         $container = $this->getConfiguredMockContainer();
 
-        return new class ($container)
-        {
+        return new class($container) {
             use ResetPasswordControllerTrait;
 
             private $container;

--- a/tests/UnitTests/Exception/ResetPasswordExceptionTest.php
+++ b/tests/UnitTests/Exception/ResetPasswordExceptionTest.php
@@ -26,19 +26,19 @@ class ResetPasswordExceptionTest extends TestCase
     {
         yield [
             ExpiredResetPasswordTokenException::class,
-            'The link in your email is expired. Please try to reset your password again.'
+            'The link in your email is expired. Please try to reset your password again.',
         ];
         yield [
             InvalidResetPasswordTokenException::class,
-            'The reset password link is invalid. Please try to reset your password again.'
+            'The reset password link is invalid. Please try to reset your password again.',
         ];
         yield [
             TooManyPasswordRequestsException::class,
-            'You have already requested a reset password email. Please check your email or try again soon.'
+            'You have already requested a reset password email. Please check your email or try again soon.',
         ];
         yield [
             FakeRepositoryException::class,
-            'Please update the request_password_repository configuration in config/packages/reset_password.yaml to point to your "request password repository` service.'
+            'Please update the request_password_repository configuration in config/packages/reset_password.yaml to point to your "request password repository` service.',
         ];
     }
 
@@ -56,7 +56,7 @@ class ResetPasswordExceptionTest extends TestCase
      */
     public function testImplementsResetPasswordExceptionInterface(string $exception): void
     {
-        $interfaces = class_implements($exception);
+        $interfaces = \class_implements($exception);
         self::assertArrayHasKey(ResetPasswordExceptionInterface::class, $interfaces);
     }
 }

--- a/tests/UnitTests/Generator/ResetPasswordRandomGeneratorTest.php
+++ b/tests/UnitTests/Generator/ResetPasswordRandomGeneratorTest.php
@@ -9,8 +9,8 @@
 
 namespace SymfonyCasts\Bundle\ResetPassword\Tests\UnitTests\Generator;
 
-use SymfonyCasts\Bundle\ResetPassword\Generator\ResetPasswordRandomGenerator;
 use PHPUnit\Framework\TestCase;
+use SymfonyCasts\Bundle\ResetPassword\Generator\ResetPasswordRandomGenerator;
 
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
@@ -23,7 +23,7 @@ class ResetPasswordRandomGeneratorTest extends TestCase
         $generator = new ResetPasswordRandomGenerator();
         $result = $generator->getRandomAlphaNumStr(100);
 
-        self::assertSame(100, strlen($result));
+        self::assertSame(100, \strlen($result));
     }
 
     public function testIsRandom(): void

--- a/tests/UnitTests/Generator/ResetPasswordTokenGeneratorTest.php
+++ b/tests/UnitTests/Generator/ResetPasswordTokenGeneratorTest.php
@@ -9,9 +9,9 @@
 
 namespace SymfonyCasts\Bundle\ResetPassword\Tests\UnitTests\Generator;
 
+use PHPUnit\Framework\TestCase;
 use SymfonyCasts\Bundle\ResetPassword\Generator\ResetPasswordRandomGenerator;
 use SymfonyCasts\Bundle\ResetPassword\Generator\ResetPasswordTokenGenerator;
-use PHPUnit\Framework\TestCase;
 
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
@@ -30,7 +30,7 @@ class ResetPasswordTokenGeneratorTest extends TestCase
     private $mockExpiresAt;
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected function setUp(): void
     {

--- a/tests/UnitTests/Model/ResetPasswordRequestTraitTest.php
+++ b/tests/UnitTests/Model/ResetPasswordRequestTraitTest.php
@@ -19,15 +19,13 @@ use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordRequestTrait;
  */
 class ResetPasswordRequestTraitTest extends TestCase
 {
-    private const SUT = ResetPasswordRequestTrait::class;
-
     /**
      * @var \DateTimeImmutable
      */
     private $expiresAt;
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected function setUp(): void
     {
@@ -36,8 +34,7 @@ class ResetPasswordRequestTraitTest extends TestCase
 
     private function getFixture(): ResetPasswordRequestInterface
     {
-        return new class ($this->expiresAt, '', '') implements ResetPasswordRequestInterface
-        {
+        return new class($this->expiresAt, '', '') implements ResetPasswordRequestInterface {
             use ResetPasswordRequestTrait;
 
             public function __construct($expiresAt, $selector, $token)
@@ -45,15 +42,14 @@ class ResetPasswordRequestTraitTest extends TestCase
                 $this->initialize($expiresAt, $selector, $token);
             }
 
-            /**
+            /*
              * getUser() is intentionally left out of the trait.
              * it is created via maker under App\Entity\PasswordResetRequest
              * as the user property, specifically its target entity,
              * is unknown to the ResetPassword bundle. Although getUser()
              * could be added to the trait within the bundle, for clarity
              * sake, the maker creates the method.
-             **/
-
+             */
             public function getUser(): object
             {
             }
@@ -80,10 +76,10 @@ class ResetPasswordRequestTraitTest extends TestCase
      */
     public function testORMAnnotationSetOnProperty(string $propertyName, string $expectedAnnotation): void
     {
-        $property = new \ReflectionProperty(self::SUT, $propertyName);
+        $property = new \ReflectionProperty(ResetPasswordRequestTrait::class, $propertyName);
         $result = $property->getDocComment();
 
-        self::assertStringContainsString($expectedAnnotation, $result, sprintf('%s::%s does not contain "%s" in the docBlock.', self::SUT, $propertyName, $expectedAnnotation));
+        self::assertStringContainsString($expectedAnnotation, $result, \sprintf('%s::%s does not contain "%s" in the docBlock.', ResetPasswordRequestTrait::class, $propertyName, $expectedAnnotation));
     }
 
     public function testIsExpiredReturnsFalseWithTimeInFuture(): void
@@ -91,7 +87,7 @@ class ResetPasswordRequestTraitTest extends TestCase
         $this->expiresAt
             ->expects($this->once())
             ->method('getTimestamp')
-            ->willReturn(time() + (360))
+            ->willReturn(\time() + (360))
         ;
 
         $trait = $this->getFixture();
@@ -103,7 +99,7 @@ class ResetPasswordRequestTraitTest extends TestCase
         $this->expiresAt
             ->expects($this->once())
             ->method('getTimestamp')
-            ->willReturn(time() - (360))
+            ->willReturn(\time() - (360))
         ;
 
         $trait = $this->getFixture();

--- a/tests/UnitTests/Model/ResetPasswordTokenComponentsTest.php
+++ b/tests/UnitTests/Model/ResetPasswordTokenComponentsTest.php
@@ -18,7 +18,7 @@ use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordTokenComponents;
  */
 class ResetPasswordTokenComponentsTest extends TestCase
 {
-    public function testReturnsSelectAndVerifierAsString(): void
+    public function testGetPublicTokenReturnsConcatenatedSelectorAndVerifier(): void
     {
         $tokenComponents = new ResetPasswordTokenComponents(
             'selector',

--- a/tests/UnitTests/Model/ResetPasswordTokenComponentsTest.php
+++ b/tests/UnitTests/Model/ResetPasswordTokenComponentsTest.php
@@ -9,8 +9,8 @@
 
 namespace SymfonyCasts\Bundle\ResetPassword\Tests\UnitTests\Model;
 
-use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordTokenComponents;
 use PHPUnit\Framework\TestCase;
+use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordTokenComponents;
 
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>

--- a/tests/UnitTests/Persistence/FakeResetPasswordInternalRepositoryTest.php
+++ b/tests/UnitTests/Persistence/FakeResetPasswordInternalRepositoryTest.php
@@ -9,10 +9,10 @@
 
 namespace SymfonyCasts\Bundle\ResetPassword\Tests\UnitTests\Persistence;
 
+use PHPUnit\Framework\TestCase;
 use SymfonyCasts\Bundle\ResetPassword\Exception\FakeRepositoryException;
 use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordRequestInterface;
 use SymfonyCasts\Bundle\ResetPassword\Persistence\Fake\FakeResetPasswordInternalRepository;
-use PHPUnit\Framework\TestCase;
 
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>

--- a/tests/UnitTests/Persistence/ResetPasswordRequestRepositoryTraitTest.php
+++ b/tests/UnitTests/Persistence/ResetPasswordRequestRepositoryTraitTest.php
@@ -9,10 +9,10 @@
 
 namespace SymfonyCasts\Bundle\ResetPassword\Tests\UnitTests\Persistence;
 
-use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordRequestInterface;
-use SymfonyCasts\Bundle\ResetPassword\Persistence\ResetPasswordRequestRepositoryInterface;
 use PHPUnit\Framework\TestCase;
+use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordRequestInterface;
 use SymfonyCasts\Bundle\ResetPassword\Persistence\Repository\ResetPasswordRequestRepositoryTrait;
+use SymfonyCasts\Bundle\ResetPassword\Persistence\ResetPasswordRequestRepositoryInterface;
 
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
@@ -22,7 +22,7 @@ class ResetPasswordRequestRepositoryTraitTest extends TestCase
 {
     public function testTraitIsCompatibleWithInterface(): void
     {
-        $sut = new class implements ResetPasswordRequestRepositoryInterface{
+        $fixture = new class() implements ResetPasswordRequestRepositoryInterface {
             use ResetPasswordRequestRepositoryTrait;
 
             public function createResetPasswordRequest(
@@ -30,11 +30,10 @@ class ResetPasswordRequestRepositoryTraitTest extends TestCase
                 \DateTimeInterface $expiresAt,
                 string $selector,
                 string $hashedToken
-            ): ResetPasswordRequestInterface {}
+            ): ResetPasswordRequestInterface {
+            }
         };
 
-        self::assertInstanceOf(ResetPasswordRequestRepositoryInterface::class, $sut);
+        self::assertInstanceOf(ResetPasswordRequestRepositoryInterface::class, $fixture);
     }
-    
-    //@TODO Add unit tests for trait methods in separate PR
 }

--- a/tests/UnitTests/ResetPasswordHelperTest.php
+++ b/tests/UnitTests/ResetPasswordHelperTest.php
@@ -15,8 +15,8 @@ use SymfonyCasts\Bundle\ResetPassword\Exception\InvalidResetPasswordTokenExcepti
 use SymfonyCasts\Bundle\ResetPassword\Exception\TooManyPasswordRequestsException;
 use SymfonyCasts\Bundle\ResetPassword\Generator\ResetPasswordTokenGenerator;
 use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordRequestInterface;
-use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelper;
 use SymfonyCasts\Bundle\ResetPassword\Persistence\ResetPasswordRequestRepositoryInterface;
+use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelper;
 use SymfonyCasts\Bundle\ResetPassword\Tests\Fixtures\ResetPasswordRequestTestFixture;
 use SymfonyCasts\Bundle\ResetPassword\Util\ResetPasswordCleaner;
 
@@ -57,7 +57,7 @@ class ResetPasswordHelperTest extends TestCase
     private $mockUser;
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected function setUp(): void
     {
@@ -66,7 +66,7 @@ class ResetPasswordHelperTest extends TestCase
         $this->mockCleaner = $this->createMock(ResetPasswordCleaner::class);
         $this->mockResetRequest = $this->createMock(ResetPasswordRequestInterface::class);
         $this->randomToken = \bin2hex(\random_bytes(10));
-        $this->mockUser = new class {};
+        $this->mockUser = new class() {};
     }
 
     private function getPasswordResetHelper(): ResetPasswordHelper

--- a/tests/UnitTests/Util/ResetPasswordCleanerTest.php
+++ b/tests/UnitTests/Util/ResetPasswordCleanerTest.php
@@ -9,6 +9,7 @@
 
 namespace SymfonyCasts\Bundle\ResetPassword\Tests\UnitTests\Util;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use SymfonyCasts\Bundle\ResetPassword\Persistence\ResetPasswordRequestRepositoryInterface;
 use SymfonyCasts\Bundle\ResetPassword\Util\ResetPasswordCleaner;
@@ -19,16 +20,28 @@ use SymfonyCasts\Bundle\ResetPassword\Util\ResetPasswordCleaner;
  */
 class ResetPasswordCleanerTest extends TestCase
 {
-    public function testRemoveExpiredRequestCallsRepositoryTrait(): void
+    /**
+     * @var MockObject|ResetPasswordRequestRepositoryInterface
+     */
+    private $mockRepo;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
     {
-        $mockRepo = $this->createMock(ResetPasswordRequestRepositoryInterface::class);
-        $mockRepo
+        $this->mockRepo = $this->createMock(ResetPasswordRequestRepositoryInterface::class);
+    }
+
+    public function testGarbageCollectionEnabledByDefault(): void
+    {
+        $this->mockRepo
             ->expects($this->once())
             ->method('removeExpiredResetPasswordRequests')
             ->willReturn(1)
         ;
 
-        $cleaner = new ResetPasswordCleaner($mockRepo);
+        $cleaner = new ResetPasswordCleaner($this->mockRepo);
         $result = $cleaner->handleGarbageCollection();
 
         self::assertSame(1, $result);
@@ -36,26 +49,24 @@ class ResetPasswordCleanerTest extends TestCase
 
     public function testHandleGarbageCollectionCanBeForced(): void
     {
-        $mockRepo = $this->createMock(ResetPasswordRequestRepositoryInterface::class);
-        $mockRepo
+        $this->mockRepo
             ->expects($this->once())
             ->method('removeExpiredResetPasswordRequests')
             ->willReturn(1)
         ;
 
-        $cleaner = new ResetPasswordCleaner($mockRepo, false);
+        $cleaner = new ResetPasswordCleaner($this->mockRepo, false);
         $cleaner->handleGarbageCollection(true);
     }
 
-    public function testAreNotRemovedWhenDisabledAndNotForced(): void
+    public function testGarbageCollectionCanBeDisabled(): void
     {
-        $mockRepo = $this->createMock(ResetPasswordRequestRepositoryInterface::class);
-        $mockRepo
+        $this->mockRepo
             ->expects($this->never())
             ->method('removeExpiredResetPasswordRequests')
         ;
 
-        $cleaner = new ResetPasswordCleaner($mockRepo, false);
+        $cleaner = new ResetPasswordCleaner($this->mockRepo, false);
         $result = $cleaner->handleGarbageCollection();
 
         self::assertSame(0, $result);

--- a/tests/UnitTests/Util/ResetPasswordCleanerTest.php
+++ b/tests/UnitTests/Util/ResetPasswordCleanerTest.php
@@ -9,9 +9,9 @@
 
 namespace SymfonyCasts\Bundle\ResetPassword\Tests\UnitTests\Util;
 
+use PHPUnit\Framework\TestCase;
 use SymfonyCasts\Bundle\ResetPassword\Persistence\ResetPasswordRequestRepositoryInterface;
 use SymfonyCasts\Bundle\ResetPassword\Util\ResetPasswordCleaner;
-use PHPUnit\Framework\TestCase;
 
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>


### PR DESCRIPTION
- added test suite declarations in phpunit.xml.dist
- fixed cs-fixer related squawks
- removed constants not needed

breaking out the test suite declarations will allow ci to halt on failures earlier on, if so configured. Will also make it easier to distinguish which test suite has failed. This PR does not modify current CI behavior.