### PR TITLE
add test suite to cs fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,11 +1,11 @@
 <?php
 
-if (!file_exists(__DIR__.'/src')) {
+if (!file_exists(__DIR__.'/src') || !file_exists(__DIR__.'/tests')) {
     exit(0);
 }
 
 $finder = PhpCsFixer\Finder::create()
-    ->in(__DIR__.'/src')
+    ->in([__DIR__.'/src', __DIR__.'/tests'])
 ;
 
 return PhpCsFixer\Config::create()


### PR DESCRIPTION
php-cs-fixer checks all files in `/tests`

CI fails until #65 is pulled in