### PR TITLE
removed un-needed modify call on \DateTimeImmutable

### DIFF
--- a/src/ResetPasswordHelper.php
+++ b/src/ResetPasswordHelper.php
@@ -76,9 +76,7 @@ class ResetPasswordHelper implements ResetPasswordHelperInterface
             throw new TooManyPasswordRequestsException();
         }
 
-        $expiresAt = (new \DateTimeImmutable('now'))
-            ->modify(\sprintf('+%d seconds', $this->resetRequestLifetime))
-        ;
+        $expiresAt = new \DateTimeImmutable(\sprintf('+%d seconds', $this->resetRequestLifetime));
 
         $tokenComponents = $this->tokenGenerator->createToken($expiresAt, $this->repository->getUserIdentifier($user));
 


### PR DESCRIPTION
We were calling `modify()` with the lifetime value immediately after creating the `\DateTimeImmutable` object. Passing the lifetime value in place of `'now'` in the `\DateTimeImmutable` constructor has the same effect..