### PR TITLE
fixed selector length

### DIFF
--- a/src/Generator/ResetPasswordRandomGenerator.php
+++ b/src/Generator/ResetPasswordRandomGenerator.php
@@ -20,13 +20,15 @@ class ResetPasswordRandomGenerator
 {
     /**
      * Original credit to Laravel's Str::random() method.
+     *
+     * String length is 20 characters
      */
-    public function getRandomAlphaNumStr(int $length): string
+    public function getRandomAlphaNumStr(): string
     {
         $string = '';
 
-        while (($len = \strlen($string)) < $length) {
-            $size = $length - $len;
+        while (($len = \strlen($string)) < 20) {
+            $size = 20 - $len;
 
             $bytes = \random_bytes($size);
 

--- a/src/Generator/ResetPasswordTokenGenerator.php
+++ b/src/Generator/ResetPasswordTokenGenerator.php
@@ -20,8 +20,6 @@ use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordTokenComponents;
  */
 class ResetPasswordTokenGenerator
 {
-    private const RANDOM_STR_LENGTH = 20;
-
     /**
      * @var string Unique, random, cryptographically secure string
      */
@@ -47,10 +45,10 @@ class ResetPasswordTokenGenerator
     public function createToken(\DateTimeInterface $expiresAt, $userId, string $verifier = null): ResetPasswordTokenComponents
     {
         if (null === $verifier) {
-            $verifier = $this->randomGenerator->getRandomAlphaNumStr(self::RANDOM_STR_LENGTH);
+            $verifier = $this->randomGenerator->getRandomAlphaNumStr();
         }
 
-        $selector = $this->randomGenerator->getRandomAlphaNumStr(self::RANDOM_STR_LENGTH);
+        $selector = $this->randomGenerator->getRandomAlphaNumStr();
 
         $encodedData = \json_encode([$verifier, $userId, $expiresAt->getTimestamp()]);
 

--- a/src/Model/ResetPasswordRequestTrait.php
+++ b/src/Model/ResetPasswordRequestTrait.php
@@ -18,7 +18,7 @@ use Doctrine\ORM\Mapping as ORM;
 trait ResetPasswordRequestTrait
 {
     /**
-     * @ORM\Column(type="string", length=100)
+     * @ORM\Column(type="string", length=20)
      */
     private $selector;
 

--- a/src/ResetPasswordHelper.php
+++ b/src/ResetPasswordHelper.php
@@ -108,6 +108,10 @@ class ResetPasswordHelper implements ResetPasswordHelperInterface
     {
         $this->resetPasswordCleaner->handleGarbageCollection();
 
+        if (40 !== \strlen($fullToken)) {
+            throw new InvalidResetPasswordTokenException();
+        }
+
         $resetRequest = $this->findResetPasswordRequest($fullToken);
 
         if (null === $resetRequest) {

--- a/tests/UnitTests/Generator/ResetPasswordRandomGeneratorTest.php
+++ b/tests/UnitTests/Generator/ResetPasswordRandomGeneratorTest.php
@@ -18,20 +18,20 @@ use SymfonyCasts\Bundle\ResetPassword\Generator\ResetPasswordRandomGenerator;
  */
 class ResetPasswordRandomGeneratorTest extends TestCase
 {
-    public function testIsProvidedLength(): void
+    public function testLengthIs20(): void
     {
         $generator = new ResetPasswordRandomGenerator();
-        $result = $generator->getRandomAlphaNumStr(100);
+        $result = $generator->getRandomAlphaNumStr();
 
-        self::assertSame(100, \strlen($result));
+        self::assertSame(20, \strlen($result));
     }
 
     public function testIsRandom(): void
     {
         $generator = new ResetPasswordRandomGenerator();
 
-        $resultA = $generator->getRandomAlphaNumStr(20);
-        $resultB = $generator->getRandomAlphaNumStr(20);
+        $resultA = $generator->getRandomAlphaNumStr();
+        $resultB = $generator->getRandomAlphaNumStr();
 
         self::assertNotSame($resultA, $resultB);
     }

--- a/tests/UnitTests/Generator/ResetPasswordTokenGeneratorTest.php
+++ b/tests/UnitTests/Generator/ResetPasswordTokenGeneratorTest.php
@@ -43,7 +43,6 @@ class ResetPasswordTokenGeneratorTest extends TestCase
         $this->mockRandomGenerator
             ->expects($this->exactly(2))
             ->method('getRandomAlphaNumStr')
-            ->with(20)
         ;
 
         $generator = $this->getTokenGenerator();

--- a/tests/UnitTests/Model/ResetPasswordRequestTraitTest.php
+++ b/tests/UnitTests/Model/ResetPasswordRequestTraitTest.php
@@ -26,7 +26,7 @@ class ResetPasswordRequestTraitTest extends TestCase
 
     public function propertyDataProvider(): \Generator
     {
-        yield ['selector', '@ORM\Column(type="string", length=100)'];
+        yield ['selector', '@ORM\Column(type="string", length=20)'];
         yield ['hashedToken', '@ORM\Column(type="string", length=100)'];
         yield ['requestedAt', '@ORM\Column(type="datetime_immutable")'];
         yield ['expiresAt', '@ORM\Column(type="datetime_immutable")'];

--- a/tests/UnitTests/ResetPasswordHelperTest.php
+++ b/tests/UnitTests/ResetPasswordHelperTest.php
@@ -22,7 +22,7 @@ use SymfonyCasts\Bundle\ResetPassword\Util\ResetPasswordCleaner;
 
 /**
  * @author  Jesse Rushlow <jr@rushlow.dev>
- * @authot  Ryan Weaver   <ryan@symfonycasts.com>
+ * @author  Ryan Weaver   <ryan@symfonycasts.com>
  */
 class ResetPasswordHelperTest extends TestCase
 {

--- a/tests/UnitTests/ResetPasswordHelperTest.php
+++ b/tests/UnitTests/ResetPasswordHelperTest.php
@@ -66,7 +66,7 @@ class ResetPasswordHelperTest extends TestCase
         $this->mockCleaner = $this->createMock(ResetPasswordCleaner::class);
         $this->mockResetRequest = $this->createMock(ResetPasswordRequestInterface::class);
         $this->randomToken = \bin2hex(\random_bytes(20));
-        $this->mockUser = new class {};
+        $this->mockUser = new class() {};
     }
 
     private function getPasswordResetHelper(): ResetPasswordHelper

--- a/tests/UnitTests/ResetPasswordHelperTest.php
+++ b/tests/UnitTests/ResetPasswordHelperTest.php
@@ -65,8 +65,8 @@ class ResetPasswordHelperTest extends TestCase
         $this->mockTokenGenerator = $this->createMock(ResetPasswordTokenGenerator::class);
         $this->mockCleaner = $this->createMock(ResetPasswordCleaner::class);
         $this->mockResetRequest = $this->createMock(ResetPasswordRequestInterface::class);
-        $this->randomToken = \bin2hex(\random_bytes(10));
-        $this->mockUser = new class() {};
+        $this->randomToken = \bin2hex(\random_bytes(20));
+        $this->mockUser = new class {};
     }
 
     private function getPasswordResetHelper(): ResetPasswordHelper
@@ -173,7 +173,7 @@ class ResetPasswordHelperTest extends TestCase
         $this->mockRepo
             ->expects($this->once())
             ->method('findResetPasswordRequest')
-            ->with($this->randomToken)
+            ->with(\substr($this->randomToken, 0, 20))
             ->willReturn($this->mockResetRequest)
         ;
 
@@ -198,6 +198,14 @@ class ResetPasswordHelperTest extends TestCase
         $helper->removeResetRequest('1234');
     }
 
+    public function testExceptionThrownIfTokenLengthIsNotOfCorrectSize(): void
+    {
+        $this->expectException(InvalidResetPasswordTokenException::class);
+
+        $helper = $this->getPasswordResetHelper();
+        $helper->validateTokenAndFetchUser(\substr($this->randomToken, 0, 39));
+    }
+
     public function testExceptionIsThrownIfTokenNotFoundDuringValidation(): void
     {
         $this->mockRepo
@@ -209,7 +217,7 @@ class ResetPasswordHelperTest extends TestCase
         $this->expectException(InvalidResetPasswordTokenException::class);
 
         $helper = $this->getPasswordResetHelper();
-        $helper->validateTokenAndFetchUser('1234');
+        $helper->validateTokenAndFetchUser($this->randomToken);
     }
 
     public function testValidateTokenThrowsExceptionOnExpiredResetRequest(): void
@@ -223,7 +231,7 @@ class ResetPasswordHelperTest extends TestCase
         $this->mockRepo
             ->expects($this->once())
             ->method('findResetPasswordRequest')
-            ->with($this->randomToken)
+            ->with(\substr($this->randomToken, 0, 20))
             ->willReturn($this->mockResetRequest)
         ;
 
@@ -256,7 +264,7 @@ class ResetPasswordHelperTest extends TestCase
         $this->mockRepo
             ->expects($this->once())
             ->method('findResetPasswordRequest')
-            ->with($this->randomToken)
+            ->with(\substr($this->randomToken, 0, 20))
             ->willReturn($this->mockResetRequest)
         ;
 


### PR DESCRIPTION
The selector length stored in persistence is always 20 char long. 

- fixed column length in request trait
- removed length param in random generator
- refactored token generator and associated tests accordingly

Could be re-introduced in the future if a use case presents it's self.