### PR TITLE
refactor helper docblocks

### DIFF
--- a/src/ResetPasswordHelper.php
+++ b/src/ResetPasswordHelper.php
@@ -29,16 +29,8 @@ class ResetPasswordHelper implements ResetPasswordHelperInterface
      */
     private const SELECTOR_LENGTH = 20;
 
-    /**
-     * @var ResetPasswordTokenGenerator
-     */
     private $tokenGenerator;
-
     private $resetPasswordCleaner;
-
-    /**
-     * @var ResetPasswordRequestRepositoryInterface
-     */
     private $repository;
 
     /**

--- a/src/ResetPasswordHelper.php
+++ b/src/ResetPasswordHelper.php
@@ -53,7 +53,7 @@ class ResetPasswordHelper implements ResetPasswordHelperInterface
     }
 
     /**
-     * Generates a new password reset token, persists it & returns the token that can be emailed to the user.
+     * {@inheritdoc}
      *
      * Some of the cryptographic strategies were taken from
      * https://paragonie.com/blog/2017/02/split-tokens-token-based-authentication-protocols-without-side-channels
@@ -89,9 +89,7 @@ class ResetPasswordHelper implements ResetPasswordHelperInterface
     }
 
     /**
-     * Validate a PasswordResetRequest and fetch user from persistence.
-     *
-     * @param string $fullToken selector + non-hashed verifier token
+     * {@inheritdoc}
      *
      * @throws ExpiredResetPasswordTokenException
      * @throws InvalidResetPasswordTokenException
@@ -130,9 +128,7 @@ class ResetPasswordHelper implements ResetPasswordHelperInterface
     }
 
     /**
-     * Remove a single PasswordResetRequest object from persistence.
-     *
-     * @param string $fullToken selector + non-hashed verifier token
+     * {@inheritdoc}
      *
      * @throws InvalidResetPasswordTokenException
      */


### PR DESCRIPTION
- Removes `@param` for some helper properties
- DRY out helper docblocks by using `inheritdoc` to utilize the helper interface descriptions.