### PR TITLE
Refactor/helper tests

### DIFF
--- a/tests/UnitTests/ResetPasswordHelperTest.php
+++ b/tests/UnitTests/ResetPasswordHelperTest.php
@@ -64,17 +64,6 @@ class ResetPasswordHelperTest extends TestCase
         $this->randomToken = \bin2hex(\random_bytes(20));
     }
 
-    private function getPasswordResetHelper(): ResetPasswordHelper
-    {
-        return new ResetPasswordHelper(
-            $this->mockTokenGenerator,
-            $this->mockCleaner,
-            $this->mockRepo,
-            99999999,
-            99999999
-        );
-    }
-
     /**
      * @covers \SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelper::hasUserHisThrottling
      */
@@ -304,7 +293,10 @@ class ResetPasswordHelperTest extends TestCase
 
     public function testGenerateResetTokenCallsGarbageCollector(): void
     {
-        $this->setMockCleanerExpectations();
+        $this->mockCleaner
+            ->expects($this->once())
+            ->method('handleGarbageCollection')
+        ;
 
         $helper = $this->getPasswordResetHelper();
         $helper->generateResetToken(new \stdClass());
@@ -312,18 +304,25 @@ class ResetPasswordHelperTest extends TestCase
 
     public function testGarbageCollectorCalledDuringValidation(): void
     {
-        $this->setMockCleanerExpectations();
+        $this->mockCleaner
+            ->expects($this->once())
+            ->method('handleGarbageCollection')
+        ;
+
         $this->expectException(InvalidResetPasswordTokenException::class);
 
         $helper = $this->getPasswordResetHelper();
         $helper->validateTokenAndFetchUser($this->randomToken);
     }
 
-    private function setMockCleanerExpectations(): void
+    private function getPasswordResetHelper(): ResetPasswordHelper
     {
-        $this->mockCleaner
-            ->expects($this->once())
-            ->method('handleGarbageCollection')
-        ;
+        return new ResetPasswordHelper(
+            $this->mockTokenGenerator,
+            $this->mockCleaner,
+            $this->mockRepo,
+            99999999,
+            99999999
+        );
     }
 }

--- a/tests/UnitTests/ResetPasswordHelperTest.php
+++ b/tests/UnitTests/ResetPasswordHelperTest.php
@@ -93,6 +93,7 @@ class ResetPasswordHelperTest extends TestCase
         ;
 
         $this->mockRepo
+            ->expects($this->once())
             ->method('createResetPasswordRequest')
             ->willReturn(new ResetPasswordTestFixtureRequest())
         ;
@@ -126,6 +127,7 @@ class ResetPasswordHelperTest extends TestCase
         ;
 
         $this->mockRepo
+            ->expects($this->once())
             ->method('createResetPasswordRequest')
             ->willReturn(new ResetPasswordTestFixtureRequest())
         ;
@@ -179,6 +181,7 @@ class ResetPasswordHelperTest extends TestCase
     public function testRemoveResetRequestCallsRepositoryToRemoveResetRequestObject(): void
     {
         $this->mockRepo
+            ->expects($this->once())
             ->method('findResetPasswordRequest')
             ->willReturn($this->mockResetRequest)
         ;

--- a/tests/UnitTests/ResetPasswordHelperTest.php
+++ b/tests/UnitTests/ResetPasswordHelperTest.php
@@ -9,6 +9,7 @@
 
 namespace SymfonyCasts\Bundle\ResetPassword\Tests\UnitTests;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use SymfonyCasts\Bundle\ResetPassword\Exception\ExpiredResetPasswordTokenException;
 use SymfonyCasts\Bundle\ResetPassword\Exception\InvalidResetPasswordTokenException;
@@ -27,22 +28,22 @@ use SymfonyCasts\Bundle\ResetPassword\Util\ResetPasswordCleaner;
 class ResetPasswordHelperTest extends TestCase
 {
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|ResetPasswordRequestRepositoryInterface
+     * @var MockObject|ResetPasswordRequestRepositoryInterface
      */
     private $mockRepo;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|ResetPasswordTokenGenerator
+     * @var MockObject|ResetPasswordTokenGenerator
      */
     private $mockTokenGenerator;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|ResetPasswordRequestInterface
+     * @var MockObject|ResetPasswordRequestInterface
      */
     private $mockResetRequest;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|ResetPasswordCleaner
+     * @var MockObject|ResetPasswordCleaner
      */
     private $mockCleaner;
 
@@ -50,11 +51,6 @@ class ResetPasswordHelperTest extends TestCase
      * @var string
      */
     private $randomToken;
-
-    /**
-     * @var object
-     */
-    private $mockUser;
 
     /**
      * {@inheritdoc}
@@ -66,7 +62,6 @@ class ResetPasswordHelperTest extends TestCase
         $this->mockCleaner = $this->createMock(ResetPasswordCleaner::class);
         $this->mockResetRequest = $this->createMock(ResetPasswordRequestInterface::class);
         $this->randomToken = \bin2hex(\random_bytes(20));
-        $this->mockUser = new class() {};
     }
 
     private function getPasswordResetHelper(): ResetPasswordHelper
@@ -103,7 +98,7 @@ class ResetPasswordHelperTest extends TestCase
         ;
 
         $helper = $this->getPasswordResetHelper();
-        $helper->generateResetToken($this->mockUser);
+        $helper->generateResetToken(new \stdClass());
     }
 
     /**
@@ -136,7 +131,7 @@ class ResetPasswordHelperTest extends TestCase
         ;
 
         $helper = $this->getPasswordResetHelper();
-        $helper->generateResetToken($this->mockUser);
+        $helper->generateResetToken(new \stdClass());
     }
 
     public function testExceptionThrownIfRequestBeforeThrottleLimit(): void
@@ -157,7 +152,7 @@ class ResetPasswordHelperTest extends TestCase
         $this->expectException(TooManyPasswordRequestsException::class);
 
         $helper = $this->getPasswordResetHelper();
-        $helper->generateResetToken($this->mockUser);
+        $helper->generateResetToken(new \stdClass());
     }
 
     public function testRemoveResetRequestThrowsExceptionWithEmptyToken(): void
@@ -252,7 +247,7 @@ class ResetPasswordHelperTest extends TestCase
         $this->mockResetRequest
             ->expects($this->once())
             ->method('getUser')
-            ->willReturn($this->mockUser)
+            ->willReturn(new \stdClass())
         ;
 
         $this->mockResetRequest
@@ -283,7 +278,7 @@ class ResetPasswordHelperTest extends TestCase
         $this->mockResetRequest
             ->expects($this->once())
             ->method('getUser')
-            ->willReturn($this->mockUser)
+            ->willReturn(new \stdClass())
         ;
 
         $this->mockResetRequest
@@ -309,7 +304,7 @@ class ResetPasswordHelperTest extends TestCase
         $this->setMockCleanerExpectations();
 
         $helper = $this->getPasswordResetHelper();
-        $helper->generateResetToken($this->mockUser);
+        $helper->generateResetToken(new \stdClass());
     }
 
     public function testGarbageCollectorCalledDuringValidation(): void


### PR DESCRIPTION
- replaced the `mockUser` property with `stdClass` instance in test methods as needed.
- sets cleaner expectations in test methods rather than in separate callable
- moved password helper getter to bottom of class