### PR TITLE
Show PHP version in CI logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.0.0
+      
+      - name: Show PHP Version
+        run: php --version
 
       - name: Validate Composer
         run: composer validate --no-check-lock


### PR DESCRIPTION
I am pretty sure all the jobs are running on 7.4.4.