### PR TITLE
use php version matrix to set php version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,12 @@ jobs:
         php-versions: ['7.2', '7.3', '7.4']
 
     steps:
+      - name: Set PHP Version
+        run: sudo update-alternatives --set php /usr/bin/php${{ matrix.php-versions }}
+
+      - name: Verify PHP Version
+        run: php -v
+
       - name: Checkout
         uses: actions/checkout@v2.0.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           ver=$(php -v | grep -oP '(?<=PHP )\d.\d')
           echo "::set-output name=version::$ver"
-          id: php-ver
+        id: php-ver
 
       - name: Using PHP Version from matrix
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
       - name: Set PHP Version
         run: sudo update-alternatives --set php /usr/bin/php${{ matrix.php-versions }}
 
+      - name: Disable Xdebug
+        run: sudo rm /etc/php/${{ matrix.php-versions }}/cli/conf.d/20-xdebug.ini
+
       - name: Verify PHP Version
         run: php -v
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,18 @@ jobs:
       - name: Disable Xdebug
         run: sudo rm /etc/php/${{ matrix.php-versions }}/cli/conf.d/20-xdebug.ini
 
-      - name: Verify PHP Version
-        run: php -v
+      - name: Get PHP Version
+        run: |
+          ver=$(php -v | grep -oP '(?<=PHP )\d.\d')
+          echo "::set-output name=version::$ver"
+          id: php-ver
+
+      - name: Using PHP Version from matrix
+        run: |
+          echo "Runner is not using PHP Version defined in the php-versions matrix."
+          php -v
+          exit 1
+        if: steps.php-ver.outputs.version != matrix.php-versions
 
       - name: Checkout
         uses: actions/checkout@v2.0.0


### PR DESCRIPTION
PR fixes CI to actually use the PHP matrix we were previously defining but not using. See issue #82 
We also disable Xdebug in CI as we are not currently using it. 

- added CI steps to match PHP version on runner CI vs PHP version defined in the matrix. If there is a version mismatch, build fails.

If code coverage is introduced in CI, we can create a separate workflow or job for that.