### PR TITLE
ignore dev files in composer downloads

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,7 @@
+/docs export-ignore
+/.github export-ignore
 /tests export-ignore
 .php_cs.dist export-ignore
 phpunit.xml.dist export-ignore
 psalm.xml export-ignore
+README.md export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,8 @@
 /docs export-ignore
 /.github export-ignore
 /tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
 .php_cs.dist export-ignore
 phpunit.xml.dist export-ignore
 psalm.xml export-ignore
-README.md export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+/tests export-ignore
+.php_cs.dist export-ignore
+phpunit.xml.dist export-ignore
+psalm.xml export-ignore


### PR DESCRIPTION
Prevents some files from being downloaded when requiring the bundle in composer with `--prefer-dist`.

- `/docs`
- `/.github` 
- `/tests`
- `.gitattributes`
- `.gitignore`
- `.php_cs.dist`
- `phpunit.xml.dist`
- `psalm.xml`
- ~`README.md`~

closes #80 