### PR TITLE
prevent external deprecations from failing CI tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,6 +12,7 @@
         <server name="SHELL_VERBOSITY" value="-1" />
         <server name="SYMFONY_PHPUNIT_REMOVE" value="" />
         <server name="SYMFONY_PHPUNIT_VERSION" value="8.3" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>
     </php>
 
     <testsuites>


### PR DESCRIPTION
- [x] silence external deprecation notices in CI
- [ ] ~add CI build that is allowed to fail to catch all deprecation notices~

refs #85 