### PR TITLE
test bundle across all supported symfony versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         php-versions: ['7.2', '7.3', '7.4']
-        symfony-version: ['4.4.*', '5.0.1']
+        symfony-version: ['4.4.*', '5.0.*']
 
     steps:
       - name: Set PHP Version
@@ -85,7 +85,9 @@ jobs:
           SYMFONY_REQUIRE: ${{ matrix.symfony-version }}
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest
+        run: |
+          composer config minimum-stability stable
+          composer install --prefer-dist --no-progress --no-suggest
 
       - name: Unit Tests
         run: vendor/bin/simple-phpunit -c $GITHUB_WORKSPACE/phpunit.xml.dist --testsuite unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,13 +81,13 @@ jobs:
       - name: Install Global Dependencies
         run: |
           composer global require --no-progress --no-scripts --no-plugins symfony/flex dev-master
-        env:
-          SYMFONY_REQUIRE: ${{ matrix.symfony-version }}
 
       - name: Install dependencies
         run: |
           composer config minimum-stability stable
           composer install --prefer-dist --no-progress --no-suggest
+        env:
+          SYMFONY_REQUIRE: ${{ matrix.symfony-version }}
 
       - name: Unit Tests
         run: vendor/bin/simple-phpunit -c $GITHUB_WORKSPACE/phpunit.xml.dist --testsuite unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,8 @@ jobs:
       - name: Analyze Source
         run: vendor/bin/psalm -c $GITHUB_WORKSPACE/psalm.xml
 
-  phpunit-tests:
-    name: PHPUnit Test Suite
+  stable-tests:
+    name: Test against Symfony Stable
     runs-on: ubuntu-latest
 
     strategy:
@@ -88,6 +88,53 @@ jobs:
           composer install --prefer-dist --no-progress --no-suggest
         env:
           SYMFONY_REQUIRE: ${{ matrix.symfony-version }}
+
+      - name: Unit Tests
+        run: vendor/bin/simple-phpunit -c $GITHUB_WORKSPACE/phpunit.xml.dist --testsuite unit
+        if: always()
+
+      - name: Functional Tests
+        run: vendor/bin/simple-phpunit -c $GITHUB_WORKSPACE/phpunit.xml.dist --testsuite functional
+        if: always()
+
+      - name: Integration Tests
+        run: vendor/bin/simple-phpunit -c $GITHUB_WORKSPACE/phpunit.xml.dist --testsuite integration
+        if: always()
+
+  dev-master-tests:
+    name: Test against Symfony Master
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php-versions: ['7.2', '7.3', '7.4']
+
+    steps:
+      - name: Set PHP Version
+        run: sudo update-alternatives --set php /usr/bin/php${{ matrix.php-versions }}
+
+      - name: Disable Xdebug
+        run: sudo rm /etc/php/${{ matrix.php-versions }}/cli/conf.d/20-xdebug.ini
+
+      - name: Get PHP Version
+        run: |
+          ver=$(php -v | grep -oP '(?<=PHP )\d.\d')
+          echo "::set-output name=version::$ver"
+        id: php-ver
+
+      - name: Using PHP Version from matrix
+        run: |
+          echo "Runner is not using PHP Version defined in the php-versions matrix."
+          php -v
+          exit 1
+        if: steps.php-ver.outputs.version != matrix.php-versions
+
+      - name: Checkout
+        uses: actions/checkout@v2.0.0
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-suggest
 
       - name: Unit Tests
         run: vendor/bin/simple-phpunit -c $GITHUB_WORKSPACE/phpunit.xml.dist --testsuite unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,3 +147,50 @@ jobs:
       - name: Integration Tests
         run: vendor/bin/simple-phpunit -c $GITHUB_WORKSPACE/phpunit.xml.dist --testsuite integration
         if: always()
+
+  lowest-version-tests:
+    name: Test with lowest dependency versions
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php-versions: ['7.2', '7.3', '7.4']
+
+    steps:
+      - name: Set PHP Version
+        run: sudo update-alternatives --set php /usr/bin/php${{ matrix.php-versions }}
+
+      - name: Disable Xdebug
+        run: sudo rm /etc/php/${{ matrix.php-versions }}/cli/conf.d/20-xdebug.ini
+
+      - name: Get PHP Version
+        run: |
+          ver=$(php -v | grep -oP '(?<=PHP )\d.\d')
+          echo "::set-output name=version::$ver"
+        id: php-ver
+
+      - name: Using PHP Version from matrix
+        run: |
+          echo "Runner is not using PHP Version defined in the php-versions matrix."
+          php -v
+          exit 1
+        if: steps.php-ver.outputs.version != matrix.php-versions
+
+      - name: Checkout
+        uses: actions/checkout@v2.0.0
+
+      - name: Install dependencies
+        run: composer update --prefer-lowest --prefer-dist --no-progress --no-suggest
+
+      - name: Unit Tests
+        run: vendor/bin/simple-phpunit -c $GITHUB_WORKSPACE/phpunit.xml.dist --testsuite unit
+        if: always()
+
+      - name: Functional Tests
+        run: vendor/bin/simple-phpunit -c $GITHUB_WORKSPACE/phpunit.xml.dist --testsuite functional
+        if: always()
+
+      - name: Integration Tests
+        run: vendor/bin/simple-phpunit -c $GITHUB_WORKSPACE/phpunit.xml.dist --testsuite integration
+        if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         php-versions: ['7.2', '7.3', '7.4']
+        symfony-version: ['4.4.*', '5.0.1']
 
     steps:
       - name: Set PHP Version
@@ -76,6 +77,12 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v2.0.0
+
+      - name: Install Global Dependencies
+        run: |
+          composer global require --no-progress --no-scripts --no-plugins symfony/flex dev-master
+        env:
+          SYMFONY_REQUIRE: ${{ matrix.symfony-version }}
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-suggest

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require-dev": {
         "doctrine/orm": "^2.7",
         "friendsofphp/php-cs-fixer": "^2.16",
-        "symfony/framework-bundle": "^5.0",
+        "symfony/framework-bundle": "^4.4 | ^5.0",
         "symfony/phpunit-bridge": "^5.0",
         "vimeo/psalm": "^3.8",
         "doctrine/doctrine-bundle": "^2.0"

--- a/tests/Fixtures/AbstractResetPasswordTestKernel.php
+++ b/tests/Fixtures/AbstractResetPasswordTestKernel.php
@@ -85,7 +85,6 @@ class AbstractResetPasswordTestKernel extends Kernel
             ],
             'orm' => [
                 'auto_generate_proxy_classes' => true,
-                'naming_strategy' => 'doctrine.orm.naming_strategy.underscore_number_aware',
                 'auto_mapping' => true,
                 'mappings' => [
                     'App' => [


### PR DESCRIPTION
Currently CI only tests bundle against latest master branch of Symfony. This PR fixes issue #82 to test the bundle across Symfony:

- 4.4.*
- 5.0.*
- dev-master

Future supported versions will need to be added to the test matrix.