### PR TITLE
split up CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,13 @@ jobs:
         uses: actions/checkout@v2.0.0
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest
+        run: composer global require friendsofphp/php-cs-fixer --prefer-dist --no-progress --no-suggest
 
-      - name: Enforce coding standards
-        run: vendor/bin/php-cs-fixer fix --config $GITHUB_WORKSPACE/.php_cs.dist --diff --diff-format udiff --dry-run
+      - name: Where is global home
+        run: composer config --list
+
+  #      - name: Enforce coding standards
+#        run: vendor/bin/php-cs-fixer fix --config $GITHUB_WORKSPACE/.php_cs.dist --diff --diff-format udiff --dry-run
 
   build:
     name: ResetPassword

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.0.0
 
-      - name: Install dependencies
+      - name: Install PHP-CS-Fixer
         run: composer global require friendsofphp/php-cs-fixer --prefer-dist --no-progress --no-suggest
-
-      - name: Where is global home
-        run: composer config --list
 
       - name: Enforce coding standards
         run: $HOME/.composer/vendor/bin/php-cs-fixer fix --config $GITHUB_WORKSPACE/.php_cs.dist --diff --diff-format udiff --dry-run
+
+  psalm:
+    name: Psalm Static Analysis
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.0.0
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Analyze Source
+        run: vendor/bin/psalm -c $GITHUB_WORKSPACE/psalm.xml
 
   build:
     name: ResetPassword

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,13 @@ jobs:
         uses: actions/checkout@v2.0.0
 
       - name: Install dependencies
-        run: composer global require friendsofphp/php-cs-fixer --prefer-dist --no-progress --no-suggest
+        run: composer global require friendsofphp/php-cs-fixer --prefer-dist --no-progress --no-suggest --no-dev
 
       - name: Where is global home
         run: composer config --list
 
       - name: Enforce coding standards
-        run: /home/runner/vendor/bin/php-cs-fixer fix --config $GITHUB_WORKSPACE/.php_cs.dist --diff --diff-format udiff --dry-run
+        run: $HOME/.composer/vendor/bin/php-cs-fixer fix --config $GITHUB_WORKSPACE/.php_cs.dist --diff --diff-format udiff --dry-run
 
   build:
     name: ResetPassword

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,20 @@ jobs:
       - name: Validate
         run: composer validate --no-check-lock --strict
 
+  php-cs-fixer:
+    name: Lint Bundle Source
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.0.0
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Enforce coding standards
+        run: vendor/bin/php-cs-fixer fix --config $GITHUB_WORKSPACE/.php_cs.dist --diff --diff-format udiff --dry-run
+
   build:
     name: ResetPassword
     runs-on: ubuntu-latest
@@ -50,8 +64,8 @@ jobs:
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-suggest
 
-      - name: Check src with php-cs-Fixer
-        run: vendor/bin/php-cs-fixer fix --config $GITHUB_WORKSPACE/.php_cs.dist --diff --diff-format udiff --dry-run
+#      - name: Check src with php-cs-Fixer
+#        run: vendor/bin/php-cs-fixer fix --config $GITHUB_WORKSPACE/.php_cs.dist --diff --diff-format udiff --dry-run
 
       - name: Psalm Static Analysis
         run: vendor/bin/psalm -c $GITHUB_WORKSPACE/psalm.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v2.0.0
 
       - name: Install dependencies
-        run: composer global require friendsofphp/php-cs-fixer --prefer-dist --no-progress --no-suggest --update-no-dev
+        run: composer global require friendsofphp/php-cs-fixer --prefer-dist --no-progress --no-suggest
 
       - name: Where is global home
         run: composer config --list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Where is global home
         run: composer config --list
 
-  #      - name: Enforce coding standards
-#        run: vendor/bin/php-cs-fixer fix --config $GITHUB_WORKSPACE/.php_cs.dist --diff --diff-format udiff --dry-run
+      - name: Enforce coding standards
+        run: /home/runner/vendor/bin/php-cs-fixer fix --config $GITHUB_WORKSPACE/.php_cs.dist --diff --diff-format udiff --dry-run
 
   build:
     name: ResetPassword

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Analyze Source
         run: vendor/bin/psalm -c $GITHUB_WORKSPACE/psalm.xml
 
-  build:
-    name: ResetPassword
+  tests:
+    name: PHPUnit Test Suite
     runs-on: ubuntu-latest
 
     strategy:
@@ -72,18 +72,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.0.0
 
-#      - name: Validate Composer
-#        run: composer validate --no-check-lock
-
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-suggest
-
-#      - name: Check src with php-cs-Fixer
-#        run: vendor/bin/php-cs-fixer fix --config $GITHUB_WORKSPACE/.php_cs.dist --diff --diff-format udiff --dry-run
-
-      - name: Psalm Static Analysis
-        run: vendor/bin/psalm -c $GITHUB_WORKSPACE/psalm.xml
-        if: always()
 
       - name: Unit Tests
         run: vendor/bin/simple-phpunit -c $GITHUB_WORKSPACE/phpunit.xml.dist --testsuite unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,17 @@
 name: ResetPasswordBundle CI
 on: [push, pull_request]
 jobs:
+  composer-validate:
+    name: Validate composer.json
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.0.0
+
+      - name: Validate
+        run: composer validate --no-check-lock --strict
+
   build:
     name: ResetPassword
     runs-on: ubuntu-latest
@@ -33,8 +44,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.0.0
 
-      - name: Validate Composer
-        run: composer validate --no-check-lock
+#      - name: Validate Composer
+#        run: composer validate --no-check-lock
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-suggest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: ResetPasswordBundle CI
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 */12 * * *'
+
 jobs:
   composer-validate:
     name: Validate composer.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: ResetPasswordBundle CI
+name: Bundle CI
 on:
   push:
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Analyze Source
         run: vendor/bin/psalm -c $GITHUB_WORKSPACE/psalm.xml
 
-  tests:
+  phpunit-tests:
     name: PHPUnit Test Suite
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v2.0.0
 
       - name: Install dependencies
-        run: composer global require friendsofphp/php-cs-fixer --prefer-dist --no-progress --no-suggest --no-dev
+        run: composer global require friendsofphp/php-cs-fixer --prefer-dist --no-progress --no-suggest --update-no-dev
 
       - name: Where is global home
         run: composer config --list


### PR DESCRIPTION
- Moves composer validation, php-cs-fixer, & psalm to their own jobs in CI.
- Runs CI automatically every 12 hours

closes #88 