### PR TITLE
fixed remove-expired CLI command error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ find a change that break's semver, please create an issue.*
 
 *TBD*
 
+- [#93 - fixed remove-expired CLI command error](https://github.com/SymfonyCasts/reset-password-bundle/pull/93)
+
 ## v1.0.0-BETA2
 
 *April 3rd, 2020*

--- a/src/Command/ResetPasswordRemoveExpiredCommand.php
+++ b/src/Command/ResetPasswordRemoveExpiredCommand.php
@@ -50,6 +50,8 @@ class ResetPasswordRemoveExpiredCommand extends Command
 
         $intRemoved = $this->cleaner->handleGarbageCollection(true);
 
-        $output->writeln(\sprintf('Garbage collection successful. Removed %s reset password request objects.', $intRemoved));
+        $output->writeln(\sprintf('Garbage collection successful. Removed %s reset password request object(s).', $intRemoved));
+
+        return 0;
     }
 }

--- a/tests/FunctionalTests/Command/ResetPasswordRemoveExpiredCommandTest.php
+++ b/tests/FunctionalTests/Command/ResetPasswordRemoveExpiredCommandTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of the SymfonyCasts ResetPasswordBundle package.
+ * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SymfonyCasts\Bundle\ResetPassword\Tests\FunctionalTests\Command;
+
+use Doctrine\Bundle\DoctrineBundle\Registry;
+use Doctrine\ORM\Tools\SchemaTool;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\CommandLoader\CommandLoaderInterface;
+use Symfony\Component\Console\Tester\CommandTester;
+use SymfonyCasts\Bundle\ResetPassword\Tests\Fixtures\AbstractResetPasswordTestKernel;
+use SymfonyCasts\Bundle\ResetPassword\Tests\Fixtures\Entity\ResetPasswordTestFixtureRequest;
+
+/**
+ * @author Jesse Rushlow <jr@rushlow.dev>
+ * @author Ryan Weaver   <ryan@symfonycasts.com>
+ *
+ * @internal
+ */
+final class ResetPasswordRemoveExpiredCommandTest extends TestCase
+{
+    /**
+     * @var \Doctrine\Common\Persistence\ObjectManager|object
+     */
+    private $manager;
+
+    /**
+     * @var CommandTester
+     */
+    private $commandTester;
+
+    protected function setUp(): void
+    {
+        $kernel = new CommandKernel();
+        $kernel->boot();
+
+        $container = $kernel->getContainer();
+
+        /** @var Registry $registry */
+        $registry = $container->get('doctrine');
+        $this->manager = $registry->getManager();
+
+        $this->configureDatabase();
+
+        /** @var CommandLoaderInterface $loader */
+        $loader = $container->get('console.command_loader');
+        $this->configureCommandTester($loader);
+    }
+
+    public function testRemoveExpiredCommandWithNothingToRemove(): void
+    {
+        $this->configureDatabase();
+
+        $this->commandTester->execute([]);
+
+        self::assertStringContainsString(
+            'Garbage collection successful. Removed 0 reset password request object(s).',
+            $this->commandTester->getDisplay()
+        );
+    }
+
+    public function testRemovedExpiredCommand(): void
+    {
+        $request = new ResetPasswordTestFixtureRequest();
+        $request->expiresAt = new \DateTimeImmutable('-2 hours');
+
+        $this->manager->persist($request);
+        $this->manager->flush();
+
+        $this->commandTester->execute([]);
+
+        self::assertStringContainsString(
+            'Garbage collection successful. Removed 1 reset password request object(s).',
+            $this->commandTester->getDisplay()
+        );
+    }
+
+    private function configureCommandTester(CommandLoaderInterface $loader): void
+    {
+        $application = new Application();
+        $application->setCommandLoader($loader);
+
+        $command = $application->find('reset-password:remove-expired');
+        $this->commandTester = new CommandTester($command);
+    }
+
+    private function configureDatabase(): void
+    {
+        $metaData = $this->manager->getMetadataFactory();
+
+        $tool = new SchemaTool($this->manager);
+        $tool->dropDatabase();
+        $tool->createSchema($metaData->getAllMetadata());
+    }
+}
+
+class CommandKernel extends AbstractResetPasswordTestKernel
+{
+}


### PR DESCRIPTION
- command returns `0` upon completion
- refactored success message
- added functional tests for command

fixes #92 