### PR TITLE
[dev] stops using doctrine common ns in test suite

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "symfony/framework-bundle": "^4.4 | ^5.0",
         "symfony/phpunit-bridge": "^5.0",
         "vimeo/psalm": "^3.8",
-        "doctrine/doctrine-bundle": "^2.0.7"
+        "doctrine/doctrine-bundle": "^2.0.3"
     },
     "conflict": {
         "doctrine/orm": "<2.7",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "symfony/framework-bundle": "^4.4 | ^5.0",
         "symfony/phpunit-bridge": "^5.0",
         "vimeo/psalm": "^3.8",
-        "doctrine/doctrine-bundle": "^2.0"
+        "doctrine/doctrine-bundle": "^2.0.7"
     },
     "conflict": {
         "doctrine/orm": "<2.7",

--- a/tests/Fixtures/AbstractResetPasswordTestKernel.php
+++ b/tests/Fixtures/AbstractResetPasswordTestKernel.php
@@ -90,7 +90,7 @@ class AbstractResetPasswordTestKernel extends Kernel
                     'App' => [
                         'is_bundle' => false,
                         'type' => 'annotation',
-                        'dir' => '%kernel.project_dir%/tests/Fixtures/Entity/',
+                        'dir' => 'tests/Fixtures/Entity/',
                         'prefix' => 'SymfonyCasts\Bundle\ResetPassword\Tests\Fixtures\Entity',
                         'alias' => 'App',
                     ],

--- a/tests/Fixtures/ResetPasswordTestFixtureRequestRepository.php
+++ b/tests/Fixtures/ResetPasswordTestFixtureRequestRepository.php
@@ -10,7 +10,7 @@
 namespace SymfonyCasts\Bundle\ResetPassword\Tests\Fixtures;
 
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordRequestInterface;
 use SymfonyCasts\Bundle\ResetPassword\Persistence\Repository\ResetPasswordRequestRepositoryTrait;
 use SymfonyCasts\Bundle\ResetPassword\Persistence\ResetPasswordRequestRepositoryInterface;

--- a/tests/FunctionalTests/Command/ResetPasswordRemoveExpiredCommandTest.php
+++ b/tests/FunctionalTests/Command/ResetPasswordRemoveExpiredCommandTest.php
@@ -11,6 +11,7 @@ namespace SymfonyCasts\Bundle\ResetPassword\Tests\FunctionalTests\Command;
 
 use Doctrine\Bundle\DoctrineBundle\Registry;
 use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\Persistence\ObjectManager;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\CommandLoader\CommandLoaderInterface;
@@ -27,7 +28,7 @@ use SymfonyCasts\Bundle\ResetPassword\Tests\Fixtures\Entity\ResetPasswordTestFix
 final class ResetPasswordRemoveExpiredCommandTest extends TestCase
 {
     /**
-     * @var \Doctrine\Common\Persistence\ObjectManager|object
+     * @var ObjectManager|object
      */
     private $manager;
 

--- a/tests/FunctionalTests/Persistence/ResetPasswordRequestRepositoryTest.php
+++ b/tests/FunctionalTests/Persistence/ResetPasswordRequestRepositoryTest.php
@@ -11,6 +11,7 @@ namespace SymfonyCasts\Bundle\ResetPassword\Tests\FunctionalTests\Persistence;
 
 use Doctrine\Bundle\DoctrineBundle\Registry;
 use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\Persistence\ObjectManager;
 use PHPUnit\Framework\TestCase;
 use SymfonyCasts\Bundle\ResetPassword\Tests\Fixtures\AbstractResetPasswordTestKernel;
 use SymfonyCasts\Bundle\ResetPassword\Tests\Fixtures\Entity\ResetPasswordTestFixtureRequest;
@@ -26,7 +27,7 @@ use SymfonyCasts\Bundle\ResetPassword\Tests\Fixtures\ResetPasswordTestFixtureReq
 final class ResetPasswordRequestRepositoryTest extends TestCase
 {
     /**
-     * @var \Doctrine\Common\Persistence\ObjectManager|object
+     * @var ObjectManager|object
      */
     private $manager;
 

--- a/tests/UnitTests/Controller/ResetPasswordControllerTraitTest.php
+++ b/tests/UnitTests/Controller/ResetPasswordControllerTraitTest.php
@@ -27,7 +27,7 @@ class ResetPasswordControllerTraitTest extends TestCase
     private const TOKEN_KEY = 'ResetPasswordPublicToken';
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|SessionInterface
+     * @var MockObject|SessionInterface
      */
     private $mockSession;
 


### PR DESCRIPTION
Bumps the minimum `doctrine/doctrine-bundle` from `^2.0` => `^2.0.3`. This bump introduces the `Doctrine\Common\Persistence` deprecation, which is thrown in the test suite. Tests that were previously utilizing the "Common" namespace have been fixed.

fixes #95 
closes #75