### PR TITLE
[feature] add additional detail to TooManyPasswordRequestsException

### DIFF
--- a/src/Exception/TooManyPasswordRequestsException.php
+++ b/src/Exception/TooManyPasswordRequestsException.php
@@ -14,6 +14,25 @@ namespace SymfonyCasts\Bundle\ResetPassword\Exception;
  */
 final class TooManyPasswordRequestsException extends \Exception implements ResetPasswordExceptionInterface
 {
+    private $availableAt;
+
+    public function __construct(\DateTimeInterface $availableAt, string $message = '', int $code = 0, \Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+
+        $this->availableAt = $availableAt;
+    }
+
+    public function getAvailableAt(): \DateTimeInterface
+    {
+        return $this->availableAt;
+    }
+
+    public function getRetryAfter(): int
+    {
+        return $this->getAvailableAt()->getTimestamp() - (new \DateTime('now'))->getTimestamp();
+    }
+
     public function getReason(): string
     {
         return 'You have already requested a reset password email. Please check your email or try again soon.';

--- a/tests/UnitTests/Exception/ResetPasswordExceptionTest.php
+++ b/tests/UnitTests/Exception/ResetPasswordExceptionTest.php
@@ -25,19 +25,19 @@ class ResetPasswordExceptionTest extends TestCase
     public function exceptionDataProvider(): \Generator
     {
         yield [
-            ExpiredResetPasswordTokenException::class,
+            new ExpiredResetPasswordTokenException(),
             'The link in your email is expired. Please try to reset your password again.',
         ];
         yield [
-            InvalidResetPasswordTokenException::class,
+            new InvalidResetPasswordTokenException(),
             'The reset password link is invalid. Please try to reset your password again.',
         ];
         yield [
-            TooManyPasswordRequestsException::class,
+            new TooManyPasswordRequestsException(new \DateTime('+1 hour')),
             'You have already requested a reset password email. Please check your email or try again soon.',
         ];
         yield [
-            FakeRepositoryException::class,
+            new FakeRepositoryException(),
             'Please update the request_password_repository configuration in config/packages/reset_password.yaml to point to your "request password repository` service.',
         ];
     }
@@ -45,18 +45,16 @@ class ResetPasswordExceptionTest extends TestCase
     /**
      * @dataProvider exceptionDataProvider
      */
-    public function testIsReason(string $exception, string $message): void
+    public function testIsReason(ResetPasswordExceptionInterface $exception, string $message): void
     {
-        $result = new $exception();
-        self::assertSame($message, $result->getReason());
+        self::assertSame($message, $exception->getReason());
     }
 
     /**
      * @dataProvider exceptionDataProvider
      */
-    public function testImplementsResetPasswordExceptionInterface(string $exception): void
+    public function testImplementsResetPasswordExceptionInterface(ResetPasswordExceptionInterface $exception): void
     {
-        $interfaces = \class_implements($exception);
-        self::assertArrayHasKey(ResetPasswordExceptionInterface::class, $interfaces);
+        self::assertInstanceOf(ResetPasswordExceptionInterface::class, $exception);
     }
 }

--- a/tests/UnitTests/Exception/TooManyPasswordRequestsExceptionTest.php
+++ b/tests/UnitTests/Exception/TooManyPasswordRequestsExceptionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the SymfonyCasts ResetPasswordBundle package.
+ * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SymfonyCasts\Bundle\ResetPassword\Tests\UnitTests\Exception;
+
+use PHPUnit\Framework\TestCase;
+use SymfonyCasts\Bundle\ResetPassword\Exception\TooManyPasswordRequestsException;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+class TooManyPasswordRequestsExceptionTest extends TestCase
+{
+    public function testCanGetRetryAfter(): void
+    {
+        $exception = new TooManyPasswordRequestsException(new \DateTime('+1 hour'));
+
+        // account for time changes during test
+        self::assertGreaterThanOrEqual(3599, $exception->getRetryAfter());
+        self::assertLessThanOrEqual(3600, $exception->getRetryAfter());
+    }
+}


### PR DESCRIPTION
- added `getAvailableAt()` to get a `DateTime` object for when a reset can be attempted again
- added `getRetryAfter()` to get the number of seconds before a reset can be attempted again (this can be useful for 429 response status codes)

Solution for #101 