### PR TITLE
[bug] ensure all requests are removed for user

### DIFF
--- a/src/Persistence/Repository/ResetPasswordRequestRepositoryTrait.php
+++ b/src/Persistence/Repository/ResetPasswordRequestRepositoryTrait.php
@@ -61,8 +61,13 @@ trait ResetPasswordRequestRepositoryTrait
 
     public function removeResetPasswordRequest(ResetPasswordRequestInterface $resetPasswordRequest): void
     {
-        $this->getEntityManager()->remove($resetPasswordRequest);
-        $this->getEntityManager()->flush();
+        $this->createQueryBuilder('t')
+            ->delete()
+            ->where('t.user = :user')
+            ->setParameter('user', $resetPasswordRequest->getUser())
+            ->getQuery()
+            ->execute()
+        ;
     }
 
     public function removeExpiredResetPasswordRequests(): int

--- a/src/Persistence/ResetPasswordRequestRepositoryInterface.php
+++ b/src/Persistence/ResetPasswordRequestRepositoryInterface.php
@@ -53,7 +53,10 @@ interface ResetPasswordRequestRepositoryInterface
     public function getMostRecentNonExpiredRequestDate(object $user): ?\DateTimeInterface;
 
     /**
-     * Remove a single password reset request from persistence.
+     * Remove this reset password request from persistence and any other for this user.
+     *
+     * This method should remove this ResetPasswordRequestInterface and also all
+     * other ResetPasswordRequestInterface objects in storage for the same user.
      */
     public function removeResetPasswordRequest(ResetPasswordRequestInterface $resetPasswordRequest): void;
 

--- a/tests/Fixtures/Entity/ResetPasswordTestFixtureRequest.php
+++ b/tests/Fixtures/Entity/ResetPasswordTestFixtureRequest.php
@@ -26,7 +26,7 @@ final class ResetPasswordTestFixtureRequest implements ResetPasswordRequestInter
      * @ORM\GeneratedValue()
      * @ORM\Column(type="integer")
      */
-    private $id;
+    public $id;
 
     /**
      * @ORM\Column(type="string", nullable=true)
@@ -68,5 +68,6 @@ final class ResetPasswordTestFixtureRequest implements ResetPasswordRequestInter
 
     public function getUser(): object
     {
+        return $this->user;
     }
 }


### PR DESCRIPTION
A user can have multiple valid requests. This change removes them all when any one of them is used to successfully reset the user's password.

I think the BC break is negligible. Only unfortunate thing is I think the method name no longer implies what should happen here.