### PR TITLE
add PHP 8 support in CI / dev environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Set PHP Version
+        run: sudo update-alternatives --set php /usr/bin/php7.4
       - name: Checkout
         uses: actions/checkout@v2.0.0
 
       - name: Install PHP-CS-Fixer
-        run: composer global require friendsofphp/php-cs-fixer --prefer-dist --no-progress --no-suggest
+        run: composer global require friendsofphp/php-cs-fixer --prefer-dist --no-progress
 
       - name: Enforce coding standards
         run: $HOME/.composer/vendor/bin/php-cs-fixer fix --config $GITHUB_WORKSPACE/.php_cs.dist --diff --diff-format udiff --dry-run
@@ -36,11 +38,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Set PHP Version
+        run: sudo update-alternatives --set php /usr/bin/php7.4
+
       - name: Checkout
         uses: actions/checkout@v2.0.0
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest
+        run: composer install --prefer-dist --no-progress
 
       - name: Analyze Source
         run: vendor/bin/psalm -c $GITHUB_WORKSPACE/psalm.xml
@@ -53,7 +58,7 @@ jobs:
       fail-fast: false
       matrix:
         php-versions: ['7.2', '7.3', '7.4', '8.0']
-        symfony-version: ['4.4.*', '5.0.*', '5.1.*', '5.2.*']
+        symfony-version: ['4.4.*', '5.2.*']
 
     steps:
       - name: Set PHP Version
@@ -85,7 +90,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer config minimum-stability stable
-          composer install --prefer-dist --no-progress --no-suggest
+          composer update --prefer-dist --no-progress
         env:
           SYMFONY_REQUIRE: ${{ matrix.symfony-version }}
 
@@ -134,7 +139,7 @@ jobs:
         uses: actions/checkout@v2.0.0
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest
+        run: composer update --prefer-dist --no-progress
 
       - name: Unit Tests
         run: vendor/bin/simple-phpunit -c $GITHUB_WORKSPACE/phpunit.xml.dist --testsuite unit
@@ -181,7 +186,7 @@ jobs:
         uses: actions/checkout@v2.0.0
 
       - name: Install dependencies
-        run: composer update --prefer-lowest --prefer-dist --no-progress --no-suggest
+        run: composer update --prefer-lowest --prefer-dist --no-progress
 
       - name: Unit Tests
         run: vendor/bin/simple-phpunit -c $GITHUB_WORKSPACE/phpunit.xml.dist --testsuite unit

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
     },
     "require-dev": {
         "doctrine/orm": "^2.7",
-        "friendsofphp/php-cs-fixer": "^2.16",
+        "friendsofphp/php-cs-fixer": "^2.17",
         "symfony/framework-bundle": "^4.4 | ^5.0",
         "symfony/phpunit-bridge": "^5.0",
-        "vimeo/psalm": "^3.8",
+        "vimeo/psalm": "^4.3",
         "doctrine/doctrine-bundle": "^2.0.3"
     },
     "conflict": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,19 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!-- https://phpunit.readthedocs.io/en/latest/configuration.html -->
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.3/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+        backupGlobals="false"
+        colors="true"
+        bootstrap="vendor/autoload.php"
 >
+
     <php>
-        <ini name="error_reporting" value="-1" />
-        <server name="SHELL_VERBOSITY" value="-1" />
-        <server name="SYMFONY_PHPUNIT_REMOVE" value="" />
-        <server name="SYMFONY_PHPUNIT_VERSION" value="8.3" />
+        <ini name="error_reporting" value="-1"/>
+        <server name="SHELL_VERBOSITY" value="-1"/>
+        <server name="SYMFONY_PHPUNIT_REMOVE" value=""/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>
     </php>
+
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src/</directory>
+        </include>
+        <exclude>
+            <directory>./src/Resources</directory>
+            <directory>./tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </coverage>
 
     <testsuites>
         <testsuite name="all">
@@ -29,19 +40,7 @@
             <directory>./tests/IntegrationTests</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src/</directory>
-            <exclude>
-                <directory>./src/Resources</directory>
-                <directory>./tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-
     <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
     </listeners>
 </phpunit>

--- a/psalm.xml
+++ b/psalm.xml
@@ -35,7 +35,6 @@
         <MissingReturnType errorLevel="info"/>
         <MissingPropertyType errorLevel="info"/>
         <InvalidDocblock errorLevel="info"/>
-        <MisplacedRequiredParam errorLevel="info"/>
 
         <PropertyNotSetInConstructor errorLevel="info"/>
         <MissingConstructor errorLevel="info"/>


### PR DESCRIPTION
- Removes psalm's `MisplacedRequiredParam` issue which is no longer supported.
- Updates CI for Composer 2 usage
- CI runs for `php-cs-fixer` & `psalm` are forced to use PHP 7.4 until both packages fully support PHP 8

Bumps dev dependencies to versions that support PHP 8
- `php-cs-fixer`
- `psalm`