### PR TITLE
revert unintended default UTC tz on expiresAt

### DIFF
--- a/src/ResetPasswordHelper.php
+++ b/src/ResetPasswordHelper.php
@@ -68,11 +68,9 @@ class ResetPasswordHelper implements ResetPasswordHelperInterface
             throw new TooManyPasswordRequestsException($availableAt);
         }
 
-        $generatedAt = \time();
-        $expiresAtTimestamp = $generatedAt + $this->resetRequestLifetime;
+        $expiresAt = new \DateTimeImmutable(\sprintf('+%d seconds', $this->resetRequestLifetime));
 
-        /** @var \DateTimeImmutable $expiresAt */
-        $expiresAt = \DateTimeImmutable::createFromFormat('U', (string) $expiresAtTimestamp);
+        $generatedAt = ($expiresAt->getTimestamp() - $this->resetRequestLifetime);
 
         $tokenComponents = $this->tokenGenerator->createToken($expiresAt, $this->repository->getUserIdentifier($user));
 

--- a/tests/UnitTests/ResetPasswordHelperTest.php
+++ b/tests/UnitTests/ResetPasswordHelperTest.php
@@ -323,6 +323,15 @@ class ResetPasswordHelperTest extends TestCase
         $helper->validateTokenAndFetchUser($this->randomToken);
     }
 
+    public function testExpiresAtUsesCurrentTimeZone(): void
+    {
+        $helper = $this->getPasswordResetHelper();
+        $token = $helper->generateResetToken(new \stdClass());
+
+        $expiresAt = $token->getExpiresAt();
+        self::assertSame(\date_default_timezone_get(), $expiresAt->getTimezone()->getName());
+    }
+
     private function getPasswordResetHelper(): ResetPasswordHelper
     {
         return new ResetPasswordHelper(


### PR DESCRIPTION
PR #135 inadvertently introduced a change where the token `$expiresAt` DateTimeImmutable instance was created without a timezone. (+00:00). This PR reverts that BC so that `$expiresAt` uses PHP's current time zone. 

closes #138 