### PR TITLE
helper methods for storing ResetPasswordToken in session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ find a change that break's semver, please create an issue.*
 
 ## NEXT
 
+- [#143](https://github.com/SymfonyCasts/reset-password-bundle/pull/143) Adds controller trait methods to set/get the 
+  `ResetPasswordToken::class` object in the session. The following `ResetPasswordControllerTrait::class` methods have been deprecated: 
+  `setCanCheckEmailInSession()`, `canCheckEmail()`
+
 ## v1.2.2
 
 - [#139](https://github.com/SymfonyCasts/reset-password-bundle/pull/139) Fixed regression

--- a/src/Controller/ResetPasswordControllerTrait.php
+++ b/src/Controller/ResetPasswordControllerTrait.php
@@ -11,6 +11,7 @@ namespace SymfonyCasts\Bundle\ResetPassword\Controller;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordToken;
 
 /**
  * Provides useful methods to a "reset password controller".
@@ -23,13 +24,31 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
  */
 trait ResetPasswordControllerTrait
 {
+    /**
+     * @deprecated since 1.3.0, use ResetPasswordControllerTrait::setTokenObjectInSession() instead.
+     */
     private function setCanCheckEmailInSession(): void
     {
+        trigger_deprecation(
+            'symfonycasts/reset-password-bundle',
+            '1.3.0',
+            'Storing the ResetPasswordToken object in the session is more desirable, use ResetPasswordControllerTrait::setTokenObjectInSession() instead.'
+        );
+
         $this->getSessionService()->set('ResetPasswordCheckEmail', true);
     }
 
+    /**
+     * @deprecated since 1.3.0, use ResetPasswordControllerTrait::getTokenObjectFromSession() instead.
+     */
     private function canCheckEmail(): bool
     {
+        trigger_deprecation(
+            'symfonycasts/reset-password-bundle',
+            '1.3.0',
+            'Storing the ResetPasswordToken object in the session is more desirable, use ResetPasswordControllerTrait::getTokenObjectFromSession() instead.'
+        );
+
         return $this->getSessionService()->has('ResetPasswordCheckEmail');
     }
 
@@ -43,12 +62,25 @@ trait ResetPasswordControllerTrait
         return $this->getSessionService()->get('ResetPasswordPublicToken');
     }
 
+    private function setTokenObjectInSession(ResetPasswordToken $token): void
+    {
+        $token->clearToken();
+
+        $this->getSessionService()->set('ResetPasswordToken', $token);
+    }
+
+    private function getTokenObjectFromSession(): ?ResetPasswordToken
+    {
+        return $this->getSessionService()->get('ResetPasswordToken');
+    }
+
     private function cleanSessionAfterReset(): void
     {
         $session = $this->getSessionService();
 
         $session->remove('ResetPasswordPublicToken');
         $session->remove('ResetPasswordCheckEmail');
+        $session->remove('ResetPasswordToken');
     }
 
     private function getSessionService(): SessionInterface

--- a/src/Model/ResetPasswordToken.php
+++ b/src/Model/ResetPasswordToken.php
@@ -16,7 +16,7 @@ namespace SymfonyCasts\Bundle\ResetPassword\Model;
 final class ResetPasswordToken
 {
     /**
-     * @var string selector + non-hashed verifier token
+     * @var string|null selector + non-hashed verifier token
      */
     private $token;
 
@@ -55,7 +55,19 @@ final class ResetPasswordToken
      */
     public function getToken(): string
     {
+        if (null === $this->token) {
+            throw new \RuntimeException('The token property is not set. Calling getToken() after calling clearToken() is not allowed.');
+        }
+
         return $this->token;
+    }
+
+    /**
+     * Allow the token object to be safely persisted in a session.
+     */
+    public function clearToken(): void
+    {
+        $this->token = null;
     }
 
     public function getExpiresAt(): \DateTimeInterface

--- a/tests/UnitTests/Model/ResetPasswordTokenTest.php
+++ b/tests/UnitTests/Model/ResetPasswordTokenTest.php
@@ -17,6 +17,18 @@ use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordToken;
  */
 class ResetPasswordTokenTest extends TestCase
 {
+    public function testTokenValueIsSafeForStorage(): void
+    {
+        $token = new ResetPasswordToken('1234', new \DateTimeImmutable(), \time());
+
+        $token->clearToken();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The token property is not set. Calling getToken() after calling clearToken() is not allowed.');
+
+        self::assertSame('void', $token->getToken());
+    }
+
     /**
      * @dataProvider translationIntervalDataProvider
      */


### PR DESCRIPTION
It is more desireable to store the `ResetPasswordToken::class` object in the session after it has been generated by the helper vs storing individual properties of the token class in the session.

Adds the following `ResetPasswordControllerTrait::class` methods:
- `setTokenObjectInSession(ResetPasswordToken $token): void`
- `getTokenObjectFromSession(): ?ResetPasswordToken`


Deprecates the following `ResetPasswordControllerTrait:class` methods:
- `setCanCheckEmailInSession()`
- `canCheckEmail()`

These will be removed in version `2.0` of this bundle.

refs #142 