### PR TITLE
Typo fr translation

### DIFF
--- a/src/Resources/translations/ResetPasswordBundle.fr.xlf
+++ b/src/Resources/translations/ResetPasswordBundle.fr.xlf
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="1">
                 <source>%count% year|%count% years</source>
-                <target>%count% année|%count% années</target>
+                <target>%count% an|%count% ans</target>
             </trans-unit>
             <trans-unit id="2">
                 <source>%count% month|%count% months</source>


### PR DESCRIPTION
I think "année" & "années" is not appropriate with the context. We should rather say "an" & "ans".
 Exemple : 
 ```
This password expire in 10 years.
Ce mot de passe expire dans 10 ans.
 ```