### PR TITLE
add ability to generate a fake reset token

### DIFF
--- a/src/Controller/ResetPasswordControllerTrait.php
+++ b/src/Controller/ResetPasswordControllerTrait.php
@@ -90,13 +90,4 @@ trait ResetPasswordControllerTrait
 
         return $request->getSession();
     }
-
-    /**
-     * Generate a fake token to be used in the session if needed to prevent
-     * revealing if a user exists.
-     */
-    private function getFakeToken(int $tokenLifetime): ResetPasswordToken
-    {
-        return new ResetPasswordToken('fake-token', new \DateTimeImmutable(\sprintf('+%d seconds', $tokenLifetime)), \time());
-    }
 }

--- a/src/Controller/ResetPasswordControllerTrait.php
+++ b/src/Controller/ResetPasswordControllerTrait.php
@@ -90,4 +90,13 @@ trait ResetPasswordControllerTrait
 
         return $request->getSession();
     }
+
+    /**
+     * Generate a fake token to be used in the session if needed to prevent
+     * revealing if a user exists.
+     */
+    private function getFakeToken(int $tokenLifetime): ResetPasswordToken
+    {
+        return new ResetPasswordToken('fake-token', new \DateTimeImmutable(\sprintf('+%d seconds', $tokenLifetime)), time());
+    }
 }

--- a/src/Controller/ResetPasswordControllerTrait.php
+++ b/src/Controller/ResetPasswordControllerTrait.php
@@ -97,6 +97,6 @@ trait ResetPasswordControllerTrait
      */
     private function getFakeToken(int $tokenLifetime): ResetPasswordToken
     {
-        return new ResetPasswordToken('fake-token', new \DateTimeImmutable(\sprintf('+%d seconds', $tokenLifetime)), time());
+        return new ResetPasswordToken('fake-token', new \DateTimeImmutable(\sprintf('+%d seconds', $tokenLifetime)), \time());
     }
 }

--- a/src/ResetPasswordHelper.php
+++ b/src/ResetPasswordHelper.php
@@ -154,6 +154,20 @@ class ResetPasswordHelper implements ResetPasswordHelperInterface
         return $this->resetRequestLifetime;
     }
 
+    /**
+     * Generate a fake reset token.
+     *
+     * This method should not be used when timing attacks are a concern.
+     */
+    public function generateFakeResetToken(): ResetPasswordToken
+    {
+        $expiresAt = new \DateTimeImmutable(\sprintf('+%d seconds', $this->resetRequestLifetime));
+
+        $generatedAt = ($expiresAt->getTimestamp() - $this->resetRequestLifetime);
+
+        return new ResetPasswordToken('fake-token', $expiresAt, $generatedAt);
+    }
+
     private function findResetPasswordRequest(string $token): ?ResetPasswordRequestInterface
     {
         $selector = \substr($token, 0, self::SELECTOR_LENGTH);

--- a/src/ResetPasswordHelper.php
+++ b/src/ResetPasswordHelper.php
@@ -157,6 +157,11 @@ class ResetPasswordHelper implements ResetPasswordHelperInterface
     /**
      * Generate a fake reset token.
      *
+     * Use this to generate a fake token so that you can, for example, show a
+     * "reset confirmation email sent" page that includes a valid "expiration date",
+     * even if the email was not actually found (and so, a true ResetPasswordToken
+     * was not actually created).
+     *
      * This method should not be used when timing attacks are a concern.
      */
     public function generateFakeResetToken(): ResetPasswordToken

--- a/src/ResetPasswordHelperInterface.php
+++ b/src/ResetPasswordHelperInterface.php
@@ -15,6 +15,8 @@ use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordToken;
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
  * @author Ryan Weaver   <ryan@symfonycasts.com>
+ *
+ * @method ResetPasswordToken generateFakeResetToken() Generates a fake ResetPasswordToken.
  */
 interface ResetPasswordHelperInterface
 {


### PR DESCRIPTION
Now that we persist the ResetPasswordToken object in the users session when using `make:reset-password` - we need a convenient way to generate a fake token that is only persisted in the session if reset request is made on a non-existent user.

See https://github.com/symfony/maker-bundle/issues/808