### PR TITLE
[CI] run tests on ubuntu 18.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   composer-validate:
     name: Validate composer.json
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
       - name: Checkout
@@ -19,7 +19,7 @@ jobs:
 
   php-cs-fixer:
     name: Lint Bundle Source
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
       - name: Set PHP Version
@@ -35,7 +35,7 @@ jobs:
 
   psalm:
     name: Psalm Static Analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
       - name: Set PHP Version
@@ -52,7 +52,7 @@ jobs:
 
   stable-tests:
     name: Symfony Stable
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false
@@ -108,7 +108,7 @@ jobs:
 
   dev-main-tests:
     name: Symfony Main
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false
@@ -118,9 +118,6 @@ jobs:
     steps:
       - name: Set PHP Version
         run: sudo update-alternatives --set php /usr/bin/php${{ matrix.php-versions }}
-
-#      - name: Disable Xdebug
-#        run: sudo rm /etc/php/${{ matrix.php-versions }}/cli/conf.d/20-xdebug.ini
 
       - name: Get PHP Version
         run: |
@@ -155,7 +152,7 @@ jobs:
 
   lowest-version-tests:
     name: Lowest dependencies
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false
@@ -165,9 +162,6 @@ jobs:
     steps:
       - name: Set PHP Version
         run: sudo update-alternatives --set php /usr/bin/php${{ matrix.php-versions }}
-
-#      - name: Disable Xdebug
-#        run: sudo rm /etc/php/${{ matrix.php-versions }}/cli/conf.d/20-xdebug.ini
 
       - name: Get PHP Version
         run: |


### PR DESCRIPTION
Use ubuntu 1804 for tests that rely on PHP <7.4. Github released base image ubuntu-latest which uses ubuntu-20.04 - the 20.04 does not have PHP 7.0 - 7.3. Previously, ubuntu-latest was based on ubuntu-18.04