### PR TITLE
[ci] upgrade php-cs-fixer 2.x -> 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: composer global require friendsofphp/php-cs-fixer --prefer-dist --no-progress
 
       - name: Enforce coding standards
-        run: $HOME/.composer/vendor/bin/php-cs-fixer fix --config $GITHUB_WORKSPACE/.php_cs.dist --diff --diff-format udiff --dry-run
+        run: $HOME/.composer/vendor/bin/php-cs-fixer fix --config $GITHUB_WORKSPACE/.php-cs-fixer.dist.php --diff --dry-run
 
   psalm:
     name: Psalm Static Analysis

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -4,19 +4,15 @@ if (!file_exists(__DIR__.'/src') || !file_exists(__DIR__.'/tests')) {
     exit(0);
 }
 
-$finder = PhpCsFixer\Finder::create()
+$finder = (new PhpCsFixer\Finder())
     ->in([__DIR__.'/src', __DIR__.'/tests'])
 ;
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setRules(array(
         '@Symfony' => true,
         '@Symfony:risky' => true,
-        '@PHPUnit75Migration:risky' => true,
-        'array_syntax' => ['syntax' => 'short'],
-        'protected_to_private' => false,
-        'semicolon_after_instruction' => false,
-        'native_function_invocation' => true,
+        'native_function_invocation' => ['include' => ['@internal'], 'scope' => 'namespaced', 'strict' => true],
         'header_comment' => [
             'header' => <<<EOF
 This file is part of the SymfonyCasts ResetPasswordBundle package.

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     },
     "require-dev": {
         "doctrine/orm": "^2.7",
-        "friendsofphp/php-cs-fixer": "^2.17",
+        "friendsofphp/php-cs-fixer": "^3.0",
         "symfony/framework-bundle": "^4.4 | ^5.0",
         "symfony/phpunit-bridge": "^5.0",
         "vimeo/psalm": "^4.3",


### PR DESCRIPTION
- removes unnecessary rules that are already included in the `@symfony` rule sets.

this PR keeps with our current practice of going against Symfony conventions in regards to invoking native functions. e.g. for `sprintf()` <- Symfony but in the bundle `\sprintf()`.

Our current practice will be changed to follow Symfony conventions in a separate PR (avoid bloating this one).

https://cs.symfony.com/doc/rules/function_notation/native_function_invocation.html#rule-sets