### PR TITLE
follow symfony coding standards for native function invocation

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -12,7 +12,6 @@ return (new PhpCsFixer\Config())
     ->setRules(array(
         '@Symfony' => true,
         '@Symfony:risky' => true,
-        'native_function_invocation' => ['include' => ['@internal'], 'scope' => 'namespaced', 'strict' => true],
         'header_comment' => [
             'header' => <<<EOF
 This file is part of the SymfonyCasts ResetPasswordBundle package.

--- a/src/Command/ResetPasswordRemoveExpiredCommand.php
+++ b/src/Command/ResetPasswordRemoveExpiredCommand.php
@@ -50,7 +50,7 @@ class ResetPasswordRemoveExpiredCommand extends Command
 
         $intRemoved = $this->cleaner->handleGarbageCollection(true);
 
-        $output->writeln(\sprintf('Garbage collection successful. Removed %s reset password request object(s).', $intRemoved));
+        $output->writeln(sprintf('Garbage collection successful. Removed %s reset password request object(s).', $intRemoved));
 
         return 0;
     }

--- a/src/Generator/ResetPasswordRandomGenerator.php
+++ b/src/Generator/ResetPasswordRandomGenerator.php
@@ -30,10 +30,10 @@ class ResetPasswordRandomGenerator
         while (($len = \strlen($string)) < 20) {
             $size = 20 - $len;
 
-            $bytes = \random_bytes($size);
+            $bytes = random_bytes($size);
 
-            $string .= \substr(
-                \str_replace(['/', '+', '='], '', \base64_encode($bytes)), 0, $size);
+            $string .= substr(
+                str_replace(['/', '+', '='], '', base64_encode($bytes)), 0, $size);
         }
 
         return $string;

--- a/src/Generator/ResetPasswordTokenGenerator.php
+++ b/src/Generator/ResetPasswordTokenGenerator.php
@@ -50,7 +50,7 @@ class ResetPasswordTokenGenerator
 
         $selector = $this->randomGenerator->getRandomAlphaNumStr();
 
-        $encodedData = \json_encode([$verifier, $userId, $expiresAt->getTimestamp()]);
+        $encodedData = json_encode([$verifier, $userId, $expiresAt->getTimestamp()]);
 
         return new ResetPasswordTokenComponents(
             $selector,
@@ -61,6 +61,6 @@ class ResetPasswordTokenGenerator
 
     private function getHashedToken(string $data): string
     {
-        return \base64_encode(\hash_hmac('sha256', $data, $this->signingKey, true));
+        return base64_encode(hash_hmac('sha256', $data, $this->signingKey, true));
     }
 }

--- a/src/Model/ResetPasswordRequestTrait.php
+++ b/src/Model/ResetPasswordRequestTrait.php
@@ -52,7 +52,7 @@ trait ResetPasswordRequestTrait
 
     public function isExpired(): bool
     {
-        return $this->expiresAt->getTimestamp() <= \time();
+        return $this->expiresAt->getTimestamp() <= time();
     }
 
     public function getExpiresAt(): \DateTimeInterface

--- a/src/Model/ResetPasswordToken.php
+++ b/src/Model/ResetPasswordToken.php
@@ -135,7 +135,7 @@ final class ResetPasswordToken
     public function getExpiresAtIntervalInstance(): \DateInterval
     {
         if (null === $this->generatedAt) {
-            throw new \LogicException(\sprintf('%s initialized without setting the $generatedAt timestamp.', self::class));
+            throw new \LogicException(sprintf('%s initialized without setting the $generatedAt timestamp.', self::class));
         }
 
         $createdAtTime = \DateTimeImmutable::createFromFormat('U', (string) $this->generatedAt);

--- a/src/ResetPasswordHelper.php
+++ b/src/ResetPasswordHelper.php
@@ -68,7 +68,7 @@ class ResetPasswordHelper implements ResetPasswordHelperInterface
             throw new TooManyPasswordRequestsException($availableAt);
         }
 
-        $expiresAt = new \DateTimeImmutable(\sprintf('+%d seconds', $this->resetRequestLifetime));
+        $expiresAt = new \DateTimeImmutable(sprintf('+%d seconds', $this->resetRequestLifetime));
 
         $generatedAt = ($expiresAt->getTimestamp() - $this->resetRequestLifetime);
 
@@ -120,10 +120,10 @@ class ResetPasswordHelper implements ResetPasswordHelperInterface
         $hashedVerifierToken = $this->tokenGenerator->createToken(
             $resetRequest->getExpiresAt(),
             $this->repository->getUserIdentifier($user),
-            \substr($fullToken, self::SELECTOR_LENGTH)
+            substr($fullToken, self::SELECTOR_LENGTH)
         );
 
-        if (false === \hash_equals($resetRequest->getHashedToken(), $hashedVerifierToken->getHashedToken())) {
+        if (false === hash_equals($resetRequest->getHashedToken(), $hashedVerifierToken->getHashedToken())) {
             throw new InvalidResetPasswordTokenException();
         }
 
@@ -166,7 +166,7 @@ class ResetPasswordHelper implements ResetPasswordHelperInterface
      */
     public function generateFakeResetToken(): ResetPasswordToken
     {
-        $expiresAt = new \DateTimeImmutable(\sprintf('+%d seconds', $this->resetRequestLifetime));
+        $expiresAt = new \DateTimeImmutable(sprintf('+%d seconds', $this->resetRequestLifetime));
 
         $generatedAt = ($expiresAt->getTimestamp() - $this->resetRequestLifetime);
 
@@ -175,7 +175,7 @@ class ResetPasswordHelper implements ResetPasswordHelperInterface
 
     private function findResetPasswordRequest(string $token): ?ResetPasswordRequestInterface
     {
-        $selector = \substr($token, 0, self::SELECTOR_LENGTH);
+        $selector = substr($token, 0, self::SELECTOR_LENGTH);
 
         return $this->repository->findResetPasswordRequest($selector);
     }

--- a/tests/Fixtures/Entity/ResetPasswordTestFixtureRequest.php
+++ b/tests/Fixtures/Entity/ResetPasswordTestFixtureRequest.php
@@ -55,7 +55,7 @@ final class ResetPasswordTestFixtureRequest implements ResetPasswordRequestInter
 
     public function isExpired(): bool
     {
-        return $this->expiresAt->getTimestamp() <= \time();
+        return $this->expiresAt->getTimestamp() <= time();
     }
 
     public function getExpiresAt(): \DateTimeInterface

--- a/tests/ResetPasswordTestKernel.php
+++ b/tests/ResetPasswordTestKernel.php
@@ -47,7 +47,7 @@ class ResetPasswordTestKernel extends Kernel
 
     public function registerBundles(): iterable
     {
-        return \array_merge(
+        return array_merge(
             $this->extraBundles,
             [
                 new FrameworkBundle(),
@@ -133,11 +133,11 @@ class ResetPasswordTestKernel extends Kernel
 
     public function getCacheDir()
     {
-        return \sys_get_temp_dir().'/cache'.\spl_object_hash($this);
+        return sys_get_temp_dir().'/cache'.spl_object_hash($this);
     }
 
     public function getLogDir()
     {
-        return \sys_get_temp_dir().'/logs'.\spl_object_hash($this);
+        return sys_get_temp_dir().'/logs'.spl_object_hash($this);
     }
 }

--- a/tests/UnitTests/Generator/ResetPasswordTokenGeneratorTest.php
+++ b/tests/UnitTests/Generator/ResetPasswordTokenGeneratorTest.php
@@ -64,9 +64,9 @@ class ResetPasswordTokenGeneratorTest extends TestCase
             ->willReturn(2020)
         ;
 
-        $expected = \hash_hmac(
+        $expected = hash_hmac(
             'sha256',
-            \json_encode(['verifier', 'user1234', 2020]),
+            json_encode(['verifier', 'user1234', 2020]),
             'key',
             true
         );
@@ -74,7 +74,7 @@ class ResetPasswordTokenGeneratorTest extends TestCase
         $generator = $this->getTokenGenerator();
         $result = $generator->createToken($this->mockExpiresAt, 'user1234');
 
-        self::assertSame(\base64_encode($expected), $result->getHashedToken());
+        self::assertSame(base64_encode($expected), $result->getHashedToken());
     }
 
     public function testHashedTokenIsCreatedUsingOptionVerifierParam(): void
@@ -95,9 +95,9 @@ class ResetPasswordTokenGeneratorTest extends TestCase
             ->willReturn($date)
         ;
 
-        $knownToken = \hash_hmac(
+        $knownToken = hash_hmac(
             'sha256',
-            \json_encode([$knownVerifier, $userId, $date]),
+            json_encode([$knownVerifier, $userId, $date]),
             'key',
             true
         );
@@ -105,7 +105,7 @@ class ResetPasswordTokenGeneratorTest extends TestCase
         $generator = $this->getTokenGenerator();
         $result = $generator->createToken($this->mockExpiresAt, $userId, $knownVerifier);
 
-        self::assertSame(\base64_encode($knownToken), $result->getHashedToken());
+        self::assertSame(base64_encode($knownToken), $result->getHashedToken());
     }
 
     private function getTokenGenerator(): ResetPasswordTokenGenerator

--- a/tests/UnitTests/Model/ResetPasswordRequestTraitTest.php
+++ b/tests/UnitTests/Model/ResetPasswordRequestTraitTest.php
@@ -40,13 +40,13 @@ class ResetPasswordRequestTraitTest extends TestCase
         $property = new \ReflectionProperty(ResetPasswordRequestTrait::class, $propertyName);
         $result = $property->getDocComment();
 
-        self::assertStringContainsString($expectedAnnotation, $result, \sprintf('%s::%s does not contain "%s" in the docBlock.', ResetPasswordRequestTrait::class, $propertyName, $expectedAnnotation));
+        self::assertStringContainsString($expectedAnnotation, $result, sprintf('%s::%s does not contain "%s" in the docBlock.', ResetPasswordRequestTrait::class, $propertyName, $expectedAnnotation));
     }
 
     public function isExpiredDataProvider(): \Generator
     {
-        yield 'Is expired' => [(\time() + (360)), false];
-        yield 'Is Not Expired' => [(\time() - (360)), true];
+        yield 'Is expired' => [(time() + (360)), false];
+        yield 'Is Not Expired' => [(time() - (360)), true];
     }
 
     /**

--- a/tests/UnitTests/Model/ResetPasswordTokenTest.php
+++ b/tests/UnitTests/Model/ResetPasswordTokenTest.php
@@ -19,7 +19,7 @@ class ResetPasswordTokenTest extends TestCase
 {
     public function testTokenValueIsSafeForStorage(): void
     {
-        $token = new ResetPasswordToken('1234', new \DateTimeImmutable(), \time());
+        $token = new ResetPasswordToken('1234', new \DateTimeImmutable(), time());
 
         $token->clearToken();
 
@@ -34,14 +34,14 @@ class ResetPasswordTokenTest extends TestCase
      */
     public function testTranslations(int $lifetime, int $expectedInterval, string $unitOfMeasure): void
     {
-        $created = \time();
+        $created = time();
 
         $expire = \DateTimeImmutable::createFromFormat('U', (string) ($created + $lifetime));
 
         $token = new ResetPasswordToken('token', $expire, $created);
 
         self::assertSame(
-            \sprintf('%%count%% %s|%%count%% %ss', $unitOfMeasure, $unitOfMeasure),
+            sprintf('%%count%% %s|%%count%% %ss', $unitOfMeasure, $unitOfMeasure),
             $token->getExpirationMessageKey()
         );
 

--- a/tests/UnitTests/ResetPasswordHelperTest.php
+++ b/tests/UnitTests/ResetPasswordHelperTest.php
@@ -61,7 +61,7 @@ class ResetPasswordHelperTest extends TestCase
         $this->mockTokenGenerator = $this->createMock(ResetPasswordTokenGenerator::class);
         $this->mockCleaner = $this->createMock(ResetPasswordCleaner::class);
         $this->mockResetRequest = $this->createMock(ResetPasswordRequestInterface::class);
-        $this->randomToken = \bin2hex(\random_bytes(20));
+        $this->randomToken = bin2hex(random_bytes(20));
     }
 
     /**
@@ -167,7 +167,7 @@ class ResetPasswordHelperTest extends TestCase
         $this->mockRepo
             ->expects($this->once())
             ->method('findResetPasswordRequest')
-            ->with(\substr($this->randomToken, 0, 20))
+            ->with(substr($this->randomToken, 0, 20))
             ->willReturn($this->mockResetRequest)
         ;
 
@@ -198,7 +198,7 @@ class ResetPasswordHelperTest extends TestCase
         $this->expectException(InvalidResetPasswordTokenException::class);
 
         $helper = $this->getPasswordResetHelper();
-        $helper->validateTokenAndFetchUser(\substr($this->randomToken, 0, 39));
+        $helper->validateTokenAndFetchUser(substr($this->randomToken, 0, 39));
     }
 
     public function testExceptionIsThrownIfTokenNotFoundDuringValidation(): void
@@ -226,7 +226,7 @@ class ResetPasswordHelperTest extends TestCase
         $this->mockRepo
             ->expects($this->once())
             ->method('findResetPasswordRequest')
-            ->with(\substr($this->randomToken, 0, 20))
+            ->with(substr($this->randomToken, 0, 20))
             ->willReturn($this->mockResetRequest)
         ;
 
@@ -259,7 +259,7 @@ class ResetPasswordHelperTest extends TestCase
         $this->mockRepo
             ->expects($this->once())
             ->method('findResetPasswordRequest')
-            ->with(\substr($this->randomToken, 0, 20))
+            ->with(substr($this->randomToken, 0, 20))
             ->willReturn($this->mockResetRequest)
         ;
 
@@ -329,7 +329,7 @@ class ResetPasswordHelperTest extends TestCase
         $token = $helper->generateResetToken(new \stdClass());
 
         $expiresAt = $token->getExpiresAt();
-        self::assertSame(\date_default_timezone_get(), $expiresAt->getTimezone()->getName());
+        self::assertSame(date_default_timezone_get(), $expiresAt->getTimezone()->getName());
     }
 
     private function getPasswordResetHelper(): ResetPasswordHelper


### PR DESCRIPTION
as mentioned in PR #166 we should follow Symfony conventions in regards to `native_function_invocation` for consistency across the Symfony Eco-System. 

The PR reverts to past practice of using a `\` for all native functions. Instead, we follow Symfonys practice of only using the leading `\` for compiler optimized functions. 

https://cs.symfony.com/doc/rules/function_notation/native_function_invocation.html

- [x] depends on #166 