### PR TITLE
Allow using PHP 8 attributes for doctrine entities

### DIFF
--- a/src/Model/ResetPasswordRequestTrait.php
+++ b/src/Model/ResetPasswordRequestTrait.php
@@ -9,6 +9,7 @@
 
 namespace SymfonyCasts\Bundle\ResetPassword\Model;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -20,21 +21,25 @@ trait ResetPasswordRequestTrait
     /**
      * @ORM\Column(type="string", length=20)
      */
+    #[ORM\Column(type: Types::STRING, length: 20)]
     private $selector;
 
     /**
      * @ORM\Column(type="string", length=100)
      */
+    #[ORM\Column(type: Types::STRING, length: 100)]
     private $hashedToken;
 
     /**
      * @ORM\Column(type="datetime_immutable")
      */
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
     private $requestedAt;
 
     /**
      * @ORM\Column(type="datetime_immutable")
      */
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
     private $expiresAt;
 
     private function initialize(\DateTimeInterface $expiresAt, string $selector, string $hashedToken)


### PR DESCRIPTION
Fixes #174

If you enable attribute loading for doctrine, those columns of the trait will be missing. By specifying both annotations and attributes in the trait, people can use annotations or attributes in their entities as they wish.

```
doctrine:
    orm:
        mappings:
            App:
                is_bundle: false
                type: attribute / annotation
                dir: '%kernel.project_dir%/src/Entity'
                prefix: 'App\Entity'
                alias: App
```