### PR TITLE
Changing delay for removing expired password requests

### DIFF
--- a/src/Persistence/Repository/ResetPasswordRequestRepositoryTrait.php
+++ b/src/Persistence/Repository/ResetPasswordRequestRepositoryTrait.php
@@ -72,7 +72,7 @@ trait ResetPasswordRequestRepositoryTrait
 
     public function removeExpiredResetPasswordRequests(): int
     {
-        $time = new \DateTimeImmutable('-1 week');
+        $time = new \DateTimeImmutable('-1 s');
         $query = $this->createQueryBuilder('t')
             ->delete()
             ->where('t.expiresAt <= :time')


### PR DESCRIPTION
Method for removing expired password requests removes them after 1 week, and is not configurable. 

Since we have a time limit configured, and each request stores the expiration time, why not removing requests as soon as they are expired ?