### PR TITLE
[ci] Fix Psalm: Specify var type explicitly

### DIFF
--- a/src/Generator/ResetPasswordRandomGenerator.php
+++ b/src/Generator/ResetPasswordRandomGenerator.php
@@ -28,6 +28,7 @@ class ResetPasswordRandomGenerator
         $string = '';
 
         while (($len = \strlen($string)) < 20) {
+            /** @var int<1, max> $size */
             $size = 20 - $len;
 
             $bytes = random_bytes($size);


### PR DESCRIPTION
Fixes this error:
> ERROR: ArgumentTypeCoercion - src/Generator/ResetPasswordRandomGenerator.php:33:35 - Argument 1 of random_bytes expects positive-int, parent type int provided (see https://psalm.dev/193)
>            $bytes = random_bytes($size);