### PR TITLE
Add French translations for the exceptions

### DIFF
--- a/src/Resources/translations/ResetPasswordBundle.fr.xlf
+++ b/src/Resources/translations/ResetPasswordBundle.fr.xlf
@@ -22,6 +22,30 @@
                 <source>%count% minute|%count% minutes</source>
                 <target>%count% minute|%count% minutes</target>
             </trans-unit>
+            <trans-unit id="6">
+                <source>There was a problem validating your password reset request</source>
+                <target>Un problème est survenu lors de la validation de votre demande de réinitialisation de mot de passe</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>There was a problem handling your password reset request</source>
+                <target>Un problème est survenu lors du traitement de votre demande de réinitialisation de mot de passe</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>The link in your email is expired. Please try to reset your password again.</source>
+                <target>Le lien dans votre e-mail est expiré. Veuillez réessayer de réinitialiser votre mot de passe.</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>Please update the request_password_repository configuration in config/packages/reset_password.yaml to point to your "request password repository" service.</source>
+                <target>Veuillez mettre à jour la configuration de request_password_repository dans config/packages/reset_password.yaml pour pointer vers votre service "request password repository"</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>The reset password link is invalid. Please try to reset your password again.</source>
+                <target>Le lien de réinitialisation du mot de passe n'est pas valide. Veuillez réessayer de réinitialiser votre mot de passe</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>You have already requested a reset password email. Please check your email or try again soon.</source>
+                <target>Vous avez déjà demandé un e-mail de réinitialisation du mot de passe. Veuillez vérifier votre e-mail ou réessayer bientôt.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
I just saw that the translations have been added for the exceptions, that is awesome thanks.

I have added the translations for French. The one thing people might disagree over is keeping the word `email`, depending on who you talk to they can prefer, `courriel`, `courrier-électronique`, `Mel`, ...

