### PR TITLE
[release] v1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 *We intend to follow [Semantic Versioning 2.0.0](https://semver.org/), if you 
 find a change that break's semver, please create an issue.*
 
+## [v1.13.0](https://github.com/symfonycasts/reset-password-bundle/releases/tag/v1.13.0)
+
+*February 23rd, 2022*
+
+### Feature
+
+- [#216](https://github.com/symfonycasts/reset-password-bundle/pull/216) - Changed private to protected for the ResetPasswordRequestTrait - *@DavidBilodeau1*
+- [#215](https://github.com/symfonycasts/reset-password-bundle/pull/215) - Added spanish translation for exceptions - *@idmarinas*
+- [#214](https://github.com/symfonycasts/reset-password-bundle/pull/214) - Add French translations for the exceptions - *@DennisdeBest*
+
 ## [v1.12.0](https://github.com/symfonycasts/reset-password-bundle/releases/tag/v1.12.0)
 
 *February 14th, 2022*


### PR DESCRIPTION
# Release

Howdy Resetters!

We've made it easier to use the bundle with multiple entities that need reset password functionality thanks to @DavidBilodeau1. We've also added French and Spanish translations for exceptions! 

## [v1.13.0](https://github.com/symfonycasts/reset-password-bundle/releases/tag/v1.13.0)

*February 23rd, 2022*

### Feature

- [#216](https://github.com/symfonycasts/reset-password-bundle/pull/216) - Changed private to protected for the ResetPasswordRequestTrait - *@DavidBilodeau1*
- [#215](https://github.com/symfonycasts/reset-password-bundle/pull/215) - Added spanish translation for exceptions - *@idmarinas*
- [#214](https://github.com/symfonycasts/reset-password-bundle/pull/214) - Add French translations for the exceptions - *@DennisdeBest*

Diff: https://github.com/symfonycasts/reset-password-bundle/compare/v1.12.0...v1.13.0

Happy Resetting!

---

# Changelog

## [v1.13.0](https://github.com/symfonycasts/reset-password-bundle/releases/tag/v1.13.0)

*February 23rd, 2022*

### Feature

- [#216](https://github.com/symfonycasts/reset-password-bundle/pull/216) - Changed private to protected for the ResetPasswordRequestTrait - *@DavidBilodeau1*
- [#215](https://github.com/symfonycasts/reset-password-bundle/pull/215) - Added spanish translation for exceptions - *@idmarinas*
- [#214](https://github.com/symfonycasts/reset-password-bundle/pull/214) - Add French translations for the exceptions - *@DennisdeBest*
