### PR TITLE
Fix delay in PHP 8.1

### DIFF
--- a/src/Model/ResetPasswordToken.php
+++ b/src/Model/ResetPasswordToken.php
@@ -26,7 +26,7 @@ final class ResetPasswordToken
     private $expiresAt;
 
     /**
-     * @var int|null timestamp when the token was created
+     * @var \DateTimeInterface|null timestamp when the token was created
      */
     private $generatedAt;
 
@@ -35,7 +35,7 @@ final class ResetPasswordToken
      */
     private $transInterval = 0;
 
-    public function __construct(string $token, \DateTimeInterface $expiresAt, int $generatedAt = null)
+    public function __construct(string $token, \DateTimeInterface $expiresAt, \DateTimeInterface $generatedAt = null)
     {
         $this->token = $token;
         $this->expiresAt = $expiresAt;
@@ -138,9 +138,7 @@ final class ResetPasswordToken
             throw new \LogicException(sprintf('%s initialized without setting the $generatedAt timestamp.', self::class));
         }
 
-        $createdAtTime = \DateTimeImmutable::createFromFormat('U', (string) $this->generatedAt);
-
-        return $this->expiresAt->diff($createdAtTime);
+        return $this->expiresAt->diff($this->generatedAt);
     }
 
     private function triggerDeprecation(): void

--- a/src/ResetPasswordHelper.php
+++ b/src/ResetPasswordHelper.php
@@ -68,9 +68,8 @@ class ResetPasswordHelper implements ResetPasswordHelperInterface
             throw new TooManyPasswordRequestsException($availableAt);
         }
 
-        $expiresAt = new \DateTimeImmutable(sprintf('+%d seconds', $this->resetRequestLifetime));
-
-        $generatedAt = ($expiresAt->getTimestamp() - $this->resetRequestLifetime);
+        $generatedAt = new \DateTimeImmutable();
+        $expiresAt = $generatedAt->modify(sprintf('+%d seconds', $this->resetRequestLifetime));
 
         $tokenComponents = $this->tokenGenerator->createToken($expiresAt, $this->repository->getUserIdentifier($user));
 
@@ -166,9 +165,8 @@ class ResetPasswordHelper implements ResetPasswordHelperInterface
      */
     public function generateFakeResetToken(): ResetPasswordToken
     {
-        $expiresAt = new \DateTimeImmutable(sprintf('+%d seconds', $this->resetRequestLifetime));
-
-        $generatedAt = ($expiresAt->getTimestamp() - $this->resetRequestLifetime);
+        $generatedAt = new \DateTimeImmutable();
+        $expiresAt = $generatedAt->modify(sprintf('+%d seconds', $this->resetRequestLifetime));
 
         return new ResetPasswordToken('fake-token', $expiresAt, $generatedAt);
     }


### PR DESCRIPTION
the delay is always at 0 because the comparison with the timestamp is not done correctly

![image](https://user-images.githubusercontent.com/12426580/163158843-a462d6c3-1bc5-4e6f-b0d6-c725bec0ef31.png)

https://github.com/SymfonyCasts/reset-password-bundle/issues/219