### PR TITLE
[command] Fix Override deprecation

### DIFF
--- a/src/Command/ResetPasswordRemoveExpiredCommand.php
+++ b/src/Command/ResetPasswordRemoveExpiredCommand.php
@@ -20,15 +20,13 @@ use SymfonyCasts\Bundle\ResetPassword\Util\ResetPasswordCleaner;
  */
 class ResetPasswordRemoveExpiredCommand extends Command
 {
-    private static $commandName = 'reset-password:remove-expired';
-
     private $cleaner;
 
     public function __construct(ResetPasswordCleaner $cleaner)
     {
         $this->cleaner = $cleaner;
 
-        parent::__construct(self::$commandName);
+        parent::__construct('reset-password:remove-expired');
     }
 
     /**

--- a/src/Command/ResetPasswordRemoveExpiredCommand.php
+++ b/src/Command/ResetPasswordRemoveExpiredCommand.php
@@ -20,7 +20,7 @@ use SymfonyCasts\Bundle\ResetPassword\Util\ResetPasswordCleaner;
  */
 class ResetPasswordRemoveExpiredCommand extends Command
 {
-    protected static $defaultName = 'reset-password:remove-expired';
+    private static $commandName = 'reset-password:remove-expired';
 
     private $cleaner;
 
@@ -28,7 +28,7 @@ class ResetPasswordRemoveExpiredCommand extends Command
     {
         $this->cleaner = $cleaner;
 
-        parent::__construct();
+        parent::__construct(self::$commandName);
     }
 
     /**


### PR DESCRIPTION
This PR fix a deprecation message in ResetPasswordRemoveExpiredCommand.

Message is: 
The "Symfony\Component\Console\Command\Command::$defaultName" property is considered final. You should not override it in "SymfonyCasts\Bundle\ResetPassword\Command\ResetPasswordRemoveExpiredCommand".

I though of putting command name directly in constructor, but I found it more clear to leave it as property.
