### PR TITLE
fix expiration diff bug in php 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "doctrine/doctrine-bundle": "^2.0.3"
     },
     "conflict": {
+        "php": ">=8.1 <8.1.10",
         "doctrine/orm": "<2.7",
         "symfony/http-foundation": "<4.4",
         "symfony/framework-bundle": "<4.4"


### PR DESCRIPTION
### Waiting For:
- [x] PHP 8.1.10 is released.

---

https://github.com/php/php-src/issues/8730 has been merged in the `php/php-src` which fixes the `diff()` bug in PHP 8.1. 

Test failed in PHP 8.1 - 8.1.9 ->https://3v4l.org/AZpkv

Test now passes against `master` -> https://3v4l.org/AZpkv/rfc

Once PHP 8.1.10 is released, this PR will prevent users from experiencing this bug in `8.1` through `8.1.9`

fixes #219 