### PR TITLE
[git-released] v1.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 *We intend to follow [Semantic Versioning 2.0.0](https://semver.org/), if you 
 find a change that break's semver, please create an issue.*
 
+## [v1.14.1](https://github.com/symfonycasts/reset-password-bundle/releases/tag/v1.14.1)
+
+*August 6th, 2022*
+
+### Bug
+
+- [#234](https://github.com/symfonycasts/reset-password-bundle/pull/234) - [command] Fix Override deprecation - *@chindit*
+
 ## [v1.14.0](https://github.com/symfonycasts/reset-password-bundle/releases/tag/v1.14.0)
 
 *July 12th, 2022*


### PR DESCRIPTION
# Changelog

## [v1.14.1](https://github.com/symfonycasts/reset-password-bundle/releases/tag/v1.14.1)

*August 6th, 2022*

### Bug

- [#234](https://github.com/symfonycasts/reset-password-bundle/pull/234) - [command] Fix Override deprecation - *@chindit*


_Generated by Git Released_