### PR TITLE
Allow overriding the `$resetRequestLifetime` when generating a token

### DIFF
--- a/src/ResetPasswordHelper.php
+++ b/src/ResetPasswordHelper.php
@@ -60,7 +60,7 @@ class ResetPasswordHelper implements ResetPasswordHelperInterface
      *
      * @throws TooManyPasswordRequestsException
      */
-    public function generateResetToken(object $user): ResetPasswordToken
+    public function generateResetToken(object $user, ?int $resetRequestLifetime = null): ResetPasswordToken
     {
         $this->resetPasswordCleaner->handleGarbageCollection();
 
@@ -68,9 +68,11 @@ class ResetPasswordHelper implements ResetPasswordHelperInterface
             throw new TooManyPasswordRequestsException($availableAt);
         }
 
-        $expiresAt = new \DateTimeImmutable(sprintf('+%d seconds', $this->resetRequestLifetime));
+        $resetRequestLifetime = $resetRequestLifetime ?: $this->resetRequestLifetime;
 
-        $generatedAt = ($expiresAt->getTimestamp() - $this->resetRequestLifetime);
+        $expiresAt = new \DateTimeImmutable(sprintf('+%d seconds', $resetRequestLifetime));
+
+        $generatedAt = ($expiresAt->getTimestamp() - $resetRequestLifetime);
 
         $tokenComponents = $this->tokenGenerator->createToken($expiresAt, $this->repository->getUserIdentifier($user));
 
@@ -164,11 +166,12 @@ class ResetPasswordHelper implements ResetPasswordHelperInterface
      *
      * This method should not be used when timing attacks are a concern.
      */
-    public function generateFakeResetToken(): ResetPasswordToken
+    public function generateFakeResetToken(?int $resetRequestLifetime = null): ResetPasswordToken
     {
-        $expiresAt = new \DateTimeImmutable(sprintf('+%d seconds', $this->resetRequestLifetime));
+        $resetRequestLifetime = $resetRequestLifetime ?: $this->resetRequestLifetime;
+        $expiresAt = new \DateTimeImmutable(sprintf('+%d seconds', $resetRequestLifetime));
 
-        $generatedAt = ($expiresAt->getTimestamp() - $this->resetRequestLifetime);
+        $generatedAt = ($expiresAt->getTimestamp() - $resetRequestLifetime);
 
         return new ResetPasswordToken('fake-token', $expiresAt, $generatedAt);
     }

--- a/src/ResetPasswordHelperInterface.php
+++ b/src/ResetPasswordHelperInterface.php
@@ -16,7 +16,7 @@ use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordToken;
  * @author Jesse Rushlow <jr@rushlow.dev>
  * @author Ryan Weaver   <ryan@symfonycasts.com>
  *
- * @method ResetPasswordToken generateFakeResetToken() Generates a fake ResetPasswordToken.
+ * @method ResetPasswordToken generateFakeResetToken(?int $resetRequestLifetime = null) Generates a fake ResetPasswordToken.
  */
 interface ResetPasswordHelperInterface
 {
@@ -28,9 +28,11 @@ interface ResetPasswordHelperInterface
      * and removeResetRequest() can eventually invalidate it by removing it
      * from storage.
      *
+     * @param ?int $resetRequestLifetime Override the default (to be added to interface in 2.0)
+     *
      * @throws ResetPasswordExceptionInterface
      */
-    public function generateResetToken(object $user): ResetPasswordToken;
+    public function generateResetToken(object $user/*, ?int $resetRequestLifetime = null*/): ResetPasswordToken;
 
     /**
      * Validate a reset request and fetch the user from persistence.

--- a/tests/UnitTests/ResetPasswordHelperTest.php
+++ b/tests/UnitTests/ResetPasswordHelperTest.php
@@ -332,6 +332,74 @@ class ResetPasswordHelperTest extends TestCase
         self::assertSame(date_default_timezone_get(), $expiresAt->getTimezone()->getName());
     }
 
+    public function testExpiresAtUsingDefault(): void
+    {
+        $helper = new ResetPasswordHelper(
+            $this->mockTokenGenerator,
+            $this->mockCleaner,
+            $this->mockRepo,
+            60,
+            99999999
+        );
+
+        $token = $helper->generateResetToken(new \stdClass());
+        $expiresAt = $token->getExpiresAt();
+
+        self::assertGreaterThan(new \DateTimeImmutable('+55 seconds'), $expiresAt);
+        self::assertLessThan(new \DateTimeImmutable('+65 seconds'), $expiresAt);
+    }
+
+    public function testExpiresAtUsingOverride(): void
+    {
+        $helper = new ResetPasswordHelper(
+            $this->mockTokenGenerator,
+            $this->mockCleaner,
+            $this->mockRepo,
+            60,
+            99999999
+        );
+
+        $token = $helper->generateResetToken(new \stdClass(), 30);
+        $expiresAt = $token->getExpiresAt();
+
+        self::assertGreaterThan(new \DateTimeImmutable('+25 seconds'), $expiresAt);
+        self::assertLessThan(new \DateTimeImmutable('+35 seconds'), $expiresAt);
+    }
+
+    public function testFakeTokenExpiresAtUsingDefault(): void
+    {
+        $helper = new ResetPasswordHelper(
+            $this->mockTokenGenerator,
+            $this->mockCleaner,
+            $this->mockRepo,
+            60,
+            99999999
+        );
+
+        $token = $helper->generateFakeResetToken();
+        $expiresAt = $token->getExpiresAt();
+
+        self::assertGreaterThan(new \DateTimeImmutable('+55 seconds'), $expiresAt);
+        self::assertLessThan(new \DateTimeImmutable('+65 seconds'), $expiresAt);
+    }
+
+    public function testFakeTokenExpiresAtUsingOverride(): void
+    {
+        $helper = new ResetPasswordHelper(
+            $this->mockTokenGenerator,
+            $this->mockCleaner,
+            $this->mockRepo,
+            60,
+            99999999
+        );
+
+        $token = $helper->generateFakeResetToken(30);
+        $expiresAt = $token->getExpiresAt();
+
+        self::assertGreaterThan(new \DateTimeImmutable('+25 seconds'), $expiresAt);
+        self::assertLessThan(new \DateTimeImmutable('+35 seconds'), $expiresAt);
+    }
+
     private function getPasswordResetHelper(): ResetPasswordHelper
     {
         return new ResetPasswordHelper(


### PR DESCRIPTION
I have a requirement to, under certain conditions, generate a reset tokens with a different TTL than the configured default.