### PR TITLE
chore: fix type cast in `ResetPasswordRequestRepositoryTrait` when using `declare(strict_types=1);`

### DIFF
--- a/src/Persistence/Repository/ResetPasswordRequestRepositoryTrait.php
+++ b/src/Persistence/Repository/ResetPasswordRequestRepositoryTrait.php
@@ -22,7 +22,7 @@ trait ResetPasswordRequestRepositoryTrait
 {
     public function getUserIdentifier(object $user): string
     {
-        return $this->getEntityManager()
+        return (string) $this->getEntityManager()
             ->getUnitOfWork()
             ->getSingleIdentifierValue($user)
         ;


### PR DESCRIPTION
When using `declare(strict_types=1);` in `ResetPasswordRequestRepositoryTrait`, an error occurs on the token generation because the `getSingleIdentifierValue` method returns a scalar value (in my case an integer because I'm using auto-incremented integers) instead of a string as required by the method.