### PR TITLE
Fix incorrect case of getOneOrNullResult

### DIFF
--- a/src/Persistence/Repository/ResetPasswordRequestRepositoryTrait.php
+++ b/src/Persistence/Repository/ResetPasswordRequestRepositoryTrait.php
@@ -49,7 +49,7 @@ trait ResetPasswordRequestRepositoryTrait
             ->orderBy('t.requestedAt', 'DESC')
             ->setMaxResults(1)
             ->getQuery()
-            ->getOneorNullResult()
+            ->getOneOrNullResult()
         ;
 
         if (null !== $resetPasswordRequest && !$resetPasswordRequest->isExpired()) {


### PR DESCRIPTION
Not causing any issues, just something I noticed when I moved the implementation to our repository to make some adjustments.