### PR TITLE
[persistence] remove ResetPasswordRequest objects programmatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,29 @@ _Optional_ - Defaults to `true`
 Enable or disable the Reset Password Cleaner which handles expired reset password 
 requests that may have been left in persistence.
 
+## Advanced Usage
+
+### Purging `ResetPasswordRequest` objects from persistence
+
+The `ResetPasswordRequestRepositoryInterface::removeRequests()` method, which is 
+implemented in the 
+[ResetPasswordRequestRepositoryTrait](https://github.com/SymfonyCasts/reset-password-bundle/blob/main/src/Persistence/Repository/ResetPasswordRequestRepositoryTrait.php),
+can be used to remove request objects from persistence for a single user or all
+users. This differs from the 
+[garbage collection mechanism](https://github.com/SymfonyCasts/reset-password-bundle/blob/df64d82cca2ee371da5e8c03c227457069ae663e/src/Persistence/Repository/ResetPasswordRequestRepositoryTrait.php#L73)
+which only removes _expired_ request objects for _all_ users automatically.
+
+Typically, you'd call this method when you need to remove request object(s) for 
+a user who changed their email address due to suspicious activity and potentially
+has valid request objects in persistence with their "old" compromised email address.
+In such cases, pass the `user` object to `removeRequest()`.
+
+Passing `null` or omitting a `user` object will remove all request objects from
+persistence - even if any of those requests have not expired.
+
+This method relies on the user objects `primary key` being `immutable`.
+E.g. `User::id = UUID` not something like `User::id = 'john@example.com'`
+
 ## Support
 
 Feel free to open an issue for questions, problems, or suggestions with our bundle.

--- a/README.md
+++ b/README.md
@@ -121,9 +121,6 @@ Typically, you'd call this method when you need to remove request object(s) for
 a user who changed their email address due to suspicious activity and potentially
 has valid request objects in persistence with their "old" compromised email address.
 
-This method relies on the user objects `primary key` being `immutable`.
-E.g. `User::id = UUID` not something like `User::id = 'john@example.com'`.
-
 ```php
 // ProfileController
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ E.g. `User::id = UUID` not something like `User::id = 'john@example.com'`.
 #[Route(path: '/profile/{id}', name: 'app_update_profile', methods: ['GET', 'POST'])]
 public function profile(Request $request, User $user, ResetPasswordRequestRepositoryInterface $repository): Response
 {
+    $originalEmail = $user->getEmail();
+
     $form = $this->createFormBuilder($user)
         ->add('email', EmailType::class)
         ->add('save', SubmitType::class, ['label' => 'Save Profile'])
@@ -139,17 +141,13 @@ public function profile(Request $request, User $user, ResetPasswordRequestReposi
     $form->handleRequest($request);
     
     if ($form->isSubmitted() && $form->isValid()) {
-        $newEmail = $form->get('email')->getData();
-        
-        if ($newEmail !== $user->getEmail()) {
+        if ($originalEmail !== $user->getEmail()) {
             // The user changed their email address.
             // Remove any old reset requests for the user.
             $repository->removeRequests($user);
         }
         
-        // Persist the user object...
-        
-        return $this->render('success.html.twig');
+        // Persist the user object and redirect...
     }
     
     return $this->render('profile.html.twig', ['form' => $form]);

--- a/src/Persistence/Fake/FakeResetPasswordInternalRepository.php
+++ b/src/Persistence/Fake/FakeResetPasswordInternalRepository.php
@@ -61,7 +61,7 @@ final class FakeResetPasswordInternalRepository implements ResetPasswordRequestR
         throw new FakeRepositoryException();
     }
 
-    public function removeRequests(?object $user = null): void
+    public function removeRequests(object $user): void
     {
         throw new FakeRepositoryException();
     }

--- a/src/Persistence/Fake/FakeResetPasswordInternalRepository.php
+++ b/src/Persistence/Fake/FakeResetPasswordInternalRepository.php
@@ -60,4 +60,9 @@ final class FakeResetPasswordInternalRepository implements ResetPasswordRequestR
     {
         throw new FakeRepositoryException();
     }
+
+    public function removeRequests(?object $user = null): void
+    {
+        throw new FakeRepositoryException();
+    }
 }

--- a/src/Persistence/Repository/ResetPasswordRequestRepositoryTrait.php
+++ b/src/Persistence/Repository/ResetPasswordRequestRepositoryTrait.php
@@ -84,29 +84,21 @@ trait ResetPasswordRequestRepositoryTrait
     }
 
     /**
-     * Remove ResetPasswordRequest objects from persistence.
+     * Remove a users ResetPasswordRequest objects from persistence.
      *
      * Warning - This is a destructive operation. Calling this method
      * may have undesired consequences for users who have valid
      * ResetPasswordRequests but have not "checked their email" yet.
      *
-     * If a "user" object is passed, only the requests for that user
-     * will be removed.
-     *
      * @see https://github.com/SymfonyCasts/reset-password-bundle?tab=readme-ov-file#advanced-usage
      */
-    public function removeRequests(?object $user = null): void
+    public function removeRequests(object $user): void
     {
         $query = $this->createQueryBuilder('t')
             ->delete()
+            ->where('t.user = :user')
+            ->setParameter('user', $user)
         ;
-
-        if (null !== $user) {
-            $query
-                ->where('t.user = :user')
-                ->setParameter('user', $user)
-            ;
-        }
 
         $query->getQuery()->execute();
     }

--- a/src/Persistence/Repository/ResetPasswordRequestRepositoryTrait.php
+++ b/src/Persistence/Repository/ResetPasswordRequestRepositoryTrait.php
@@ -90,10 +90,10 @@ trait ResetPasswordRequestRepositoryTrait
      * may have undesired consequences for users who have valid
      * ResetPasswordRequests but have not "checked their email" yet.
      *
-     * @TODO _ @legacy This method is useful for something.....
-     *
      * If a "user" object is passed, only the requests for that user
      * will be removed.
+     *
+     * @see https://github.com/SymfonyCasts/reset-password-bundle?tab=readme-ov-file#advanced-usage
      */
     public function removeRequests(?object $user = null): void
     {

--- a/src/Persistence/Repository/ResetPasswordRequestRepositoryTrait.php
+++ b/src/Persistence/Repository/ResetPasswordRequestRepositoryTrait.php
@@ -82,4 +82,32 @@ trait ResetPasswordRequestRepositoryTrait
 
         return $query->execute();
     }
+
+    /**
+     * Remove ResetPasswordRequest objects from persistence.
+     *
+     * Warning - This is a destructive operation. Calling this method
+     * may have undesired consequences for users who have valid
+     * ResetPasswordRequests but have not "checked their email" yet.
+     *
+     * @TODO _ @legacy This method is useful for something.....
+     *
+     * If a "user" object is passed, only the requests for that user
+     * will be removed.
+     */
+    public function removeRequests(?object $user = null): void
+    {
+        $query = $this->createQueryBuilder('t')
+            ->delete()
+        ;
+
+        if (null !== $user) {
+            $query
+                ->where('t.user = :user')
+                ->setParameter('user', $user)
+            ;
+        }
+
+        $query->getQuery()->execute();
+    }
 }

--- a/src/Persistence/ResetPasswordRequestRepositoryInterface.php
+++ b/src/Persistence/ResetPasswordRequestRepositoryInterface.php
@@ -14,6 +14,8 @@ use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordRequestInterface;
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
  * @author Ryan Weaver   <ryan@symfonycasts.com>
+ *
+ * @method void removeRequests(?object $user = null) Remove ResetPasswordRequest objects from persistence.
  */
 interface ResetPasswordRequestRepositoryInterface
 {

--- a/src/Persistence/ResetPasswordRequestRepositoryInterface.php
+++ b/src/Persistence/ResetPasswordRequestRepositoryInterface.php
@@ -15,7 +15,7 @@ use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordRequestInterface;
  * @author Jesse Rushlow <jr@rushlow.dev>
  * @author Ryan Weaver   <ryan@symfonycasts.com>
  *
- * @method void removeRequests(?object $user = null) Remove ResetPasswordRequest objects from persistence.
+ * @method void removeRequests(object $user) Remove a users ResetPasswordRequest objects from persistence.
  */
 interface ResetPasswordRequestRepositoryInterface
 {

--- a/tests/FunctionalTests/Persistence/ResetPasswordRequestRepositoryTest.php
+++ b/tests/FunctionalTests/Persistence/ResetPasswordRequestRepositoryTest.php
@@ -208,18 +208,6 @@ final class ResetPasswordRequestRepositoryTest extends TestCase
         self::assertSame($futureFixture, $result[0]);
     }
 
-    public function testRemoveRequestsRemovesAllRequestsFromPersistence(): void
-    {
-        $this->manager->persist(new ResetPasswordTestFixtureRequest());
-        $this->manager->persist(new ResetPasswordTestFixtureRequest());
-
-        $this->manager->flush();
-
-        $this->repository->removeRequests();
-
-        self::assertCount(0, $this->repository->findAll());
-    }
-
     public function testRemoveRequestsRemovesAllRequestsForASingleUser(): void
     {
         $this->manager->persist($userFixture = new ResetPasswordTestFixtureUser());

--- a/tests/UnitTests/Persistence/FakeResetPasswordInternalRepositoryTest.php
+++ b/tests/UnitTests/Persistence/FakeResetPasswordInternalRepositoryTest.php
@@ -28,7 +28,7 @@ final class FakeResetPasswordInternalRepositoryTest extends TestCase
         yield ['findResetPasswordRequest', ['']];
         yield ['getMostRecentNonExpiredRequestDate', [new \stdClass()]];
         yield ['removeResetPasswordRequest', [$this->createMock(ResetPasswordRequestInterface::class)]];
-        yield ['removeRequests', []];
+        yield ['removeRequests', [new \stdClass()]];
     }
 
     /**

--- a/tests/UnitTests/Persistence/FakeResetPasswordInternalRepositoryTest.php
+++ b/tests/UnitTests/Persistence/FakeResetPasswordInternalRepositoryTest.php
@@ -28,6 +28,7 @@ final class FakeResetPasswordInternalRepositoryTest extends TestCase
         yield ['findResetPasswordRequest', ['']];
         yield ['getMostRecentNonExpiredRequestDate', [new \stdClass()]];
         yield ['removeResetPasswordRequest', [$this->createMock(ResetPasswordRequestInterface::class)]];
+        yield ['removeRequests', []];
     }
 
     /**


### PR DESCRIPTION
- [x] Update docs to say "hey, if your users `id` _is_ there email" this method won't work as expected