### PR TITLE
Add support for autowiring ResetPasswordRequestRepositoryInterface

### DIFF
--- a/src/DependencyInjection/SymfonyCastsResetPasswordExtension.php
+++ b/src/DependencyInjection/SymfonyCastsResetPasswordExtension.php
@@ -14,6 +14,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
+use SymfonyCasts\Bundle\ResetPassword\Persistence\ResetPasswordRequestRepositoryInterface;
 
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
@@ -32,6 +33,8 @@ final class SymfonyCastsResetPasswordExtension extends Extension
         }
 
         $config = $this->processConfiguration($configuration, $configs);
+
+        $container->setAlias(ResetPasswordRequestRepositoryInterface::class, $config['request_password_repository']);
 
         $helperDefinition = $container->getDefinition('symfonycasts.reset_password.helper');
         $helperDefinition->replaceArgument(2, new Reference($config['request_password_repository']));

--- a/tests/IntegrationTests/ResetPasswordRequestRepositoryInterfaceAutowireTest.php
+++ b/tests/IntegrationTests/ResetPasswordRequestRepositoryInterfaceAutowireTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the SymfonyCasts ResetPasswordBundle package.
+ * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SymfonyCasts\Bundle\ResetPassword\Tests\IntegrationTests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use SymfonyCasts\Bundle\ResetPassword\Persistence\ResetPasswordRequestRepositoryInterface;
+use SymfonyCasts\Bundle\ResetPassword\Tests\ResetPasswordTestKernel;
+
+final class ResetPasswordRequestRepositoryInterfaceAutowireTest extends TestCase
+{
+    public function testResetPasswordRequestRepositoryInterfaceIsAutowiredByContainer(): void
+    {
+        $builder = new ContainerBuilder();
+        $builder->autowire(ResetPasswordRequestRepositoryAutowireTest::class)
+            ->setPublic(true)
+        ;
+
+        $kernel = new ResetPasswordTestKernel($builder);
+        $kernel->boot();
+
+        $container = $kernel->getContainer();
+        $container->get(ResetPasswordRequestRepositoryAutowireTest::class);
+
+        $this->expectNotToPerformAssertions();
+    }
+}
+
+/**
+ * @internal
+ */
+final class ResetPasswordRequestRepositoryAutowireTest
+{
+    public function __construct(ResetPasswordRequestRepositoryInterface $repository)
+    {
+    }
+}


### PR DESCRIPTION
Just as advertised in the title, mostly motivated by implementing #284 and getting an error building the container (which could also be fixed by just referring to my repository class, but, the docs example used the interface so this removes a small bit of friction).