### PR TITLE
use constructor property promotion where possible

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,19 +1,9 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Property SymfonyCasts\\\\Bundle\\\\ResetPassword\\\\Command\\\\ResetPasswordRemoveExpiredCommand\\:\\:\\$cleaner has no type specified\\.$#"
-			count: 1
-			path: src/Command/ResetPasswordRemoveExpiredCommand.php
-
-		-
 			message: "#^Call to an undefined method Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeParentInterface\\:\\:integerNode\\(\\)\\.$#"
 			count: 1
 			path: src/DependencyInjection/Configuration.php
-
-		-
-			message: "#^Property SymfonyCasts\\\\Bundle\\\\ResetPassword\\\\Exception\\\\TooManyPasswordRequestsException\\:\\:\\$availableAt has no type specified\\.$#"
-			count: 1
-			path: src/Exception/TooManyPasswordRequestsException.php
 
 		-
 			message: "#^Method SymfonyCasts\\\\Bundle\\\\ResetPassword\\\\Model\\\\ResetPasswordToken\\:\\:getExpirationMessageData\\(\\) return type has no value type specified in iterable type array\\.$#"
@@ -21,26 +11,7 @@ parameters:
 			path: src/Model/ResetPasswordToken.php
 
 		-
-			message: "#^Property SymfonyCasts\\\\Bundle\\\\ResetPassword\\\\ResetPasswordHelper\\:\\:\\$repository has no type specified\\.$#"
-			count: 1
-			path: src/ResetPasswordHelper.php
-
-		-
-			message: "#^Property SymfonyCasts\\\\Bundle\\\\ResetPassword\\\\ResetPasswordHelper\\:\\:\\$resetPasswordCleaner has no type specified\\.$#"
-			count: 1
-			path: src/ResetPasswordHelper.php
-
-		-
-			message: "#^Property SymfonyCasts\\\\Bundle\\\\ResetPassword\\\\ResetPasswordHelper\\:\\:\\$tokenGenerator has no type specified\\.$#"
-			count: 1
-			path: src/ResetPasswordHelper.php
-
-		-
 			message: "#^PHPDoc tag @param references unknown parameter\\: \\$resetRequestLifetime$#"
 			count: 1
 			path: src/ResetPasswordHelperInterface.php
 
-		-
-			message: "#^Property SymfonyCasts\\\\Bundle\\\\ResetPassword\\\\Util\\\\ResetPasswordCleaner\\:\\:\\$repository has no type specified\\.$#"
-			count: 1
-			path: src/Util/ResetPasswordCleaner.php

--- a/src/Command/ResetPasswordRemoveExpiredCommand.php
+++ b/src/Command/ResetPasswordRemoveExpiredCommand.php
@@ -20,12 +20,9 @@ use SymfonyCasts\Bundle\ResetPassword\Util\ResetPasswordCleaner;
  */
 final class ResetPasswordRemoveExpiredCommand extends Command
 {
-    private $cleaner;
-
-    public function __construct(ResetPasswordCleaner $cleaner)
-    {
-        $this->cleaner = $cleaner;
-
+    public function __construct(
+        private ResetPasswordCleaner $cleaner
+    ) {
         parent::__construct('reset-password:remove-expired');
     }
 

--- a/src/Exception/TooManyPasswordRequestsException.php
+++ b/src/Exception/TooManyPasswordRequestsException.php
@@ -14,13 +14,9 @@ namespace SymfonyCasts\Bundle\ResetPassword\Exception;
  */
 final class TooManyPasswordRequestsException extends \Exception implements ResetPasswordExceptionInterface
 {
-    private $availableAt;
-
-    public function __construct(\DateTimeInterface $availableAt, string $message = '', int $code = 0, ?\Throwable $previous = null)
+    public function __construct(private \DateTimeInterface $availableAt, string $message = '', int $code = 0, ?\Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
-
-        $this->availableAt = $availableAt;
     }
 
     public function getAvailableAt(): \DateTimeInterface

--- a/src/Generator/ResetPasswordTokenGenerator.php
+++ b/src/Generator/ResetPasswordTokenGenerator.php
@@ -22,19 +22,12 @@ use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordTokenComponents;
 class ResetPasswordTokenGenerator
 {
     /**
-     * @var string Unique, random, cryptographically secure string
+     * @param string $signingKey Unique, random, cryptographically secure string
      */
-    private $signingKey;
-
-    /**
-     * @var ResetPasswordRandomGenerator
-     */
-    private $randomGenerator;
-
-    public function __construct(string $signingKey, ResetPasswordRandomGenerator $generator)
-    {
-        $this->signingKey = $signingKey;
-        $this->randomGenerator = $generator;
+    public function __construct(
+        private string $signingKey,
+        private ResetPasswordRandomGenerator $generator
+    ) {
     }
 
     /**
@@ -46,10 +39,10 @@ class ResetPasswordTokenGenerator
     public function createToken(\DateTimeInterface $expiresAt, $userId, ?string $verifier = null): ResetPasswordTokenComponents
     {
         if (null === $verifier) {
-            $verifier = $this->randomGenerator->getRandomAlphaNumStr();
+            $verifier = $this->generator->getRandomAlphaNumStr();
         }
 
-        $selector = $this->randomGenerator->getRandomAlphaNumStr();
+        $selector = $this->generator->getRandomAlphaNumStr();
 
         $encodedData = json_encode([$verifier, $userId, $expiresAt->getTimestamp()]);
 

--- a/src/Model/ResetPasswordTokenComponents.php
+++ b/src/Model/ResetPasswordTokenComponents.php
@@ -19,26 +19,11 @@ namespace SymfonyCasts\Bundle\ResetPassword\Model;
  */
 class ResetPasswordTokenComponents
 {
-    /**
-     * @var string
-     */
-    private $selector;
-
-    /**
-     * @var string
-     */
-    private $verifier;
-
-    /**
-     * @var string
-     */
-    private $hashedToken;
-
-    public function __construct(string $selector, string $verifier, string $hashedToken)
-    {
-        $this->selector = $selector;
-        $this->verifier = $verifier;
-        $this->hashedToken = $hashedToken;
+    public function __construct(
+        private string $selector,
+        private string $verifier,
+        private string $hashedToken
+    ) {
     }
 
     /**

--- a/src/ResetPasswordHelper.php
+++ b/src/ResetPasswordHelper.php
@@ -31,7 +31,7 @@ final class ResetPasswordHelper implements ResetPasswordHelperInterface
 
     /**
      * @param int $resetRequestLifetime How long a token is valid in seconds
-     * @param int $requestThrottleTime Another password reset cannot be made faster than this throttle time in seconds
+     * @param int $requestThrottleTime  Another password reset cannot be made faster than this throttle time in seconds
      */
     public function __construct(
         private ResetPasswordTokenGenerator $generator,

--- a/src/Util/ResetPasswordCleaner.php
+++ b/src/Util/ResetPasswordCleaner.php
@@ -22,16 +22,12 @@ use SymfonyCasts\Bundle\ResetPassword\Persistence\ResetPasswordRequestRepository
 class ResetPasswordCleaner
 {
     /**
-     * @var bool Enable/disable garbage collection
+     * @param bool $enabled Enable/disable garbage collection
      */
-    private $enabled;
-
-    private $repository;
-
-    public function __construct(ResetPasswordRequestRepositoryInterface $repository, bool $enabled = true)
-    {
-        $this->repository = $repository;
-        $this->enabled = $enabled;
+    public function __construct(
+        private ResetPasswordRequestRepositoryInterface $repository,
+        private bool $enabled = true,
+    ) {
     }
 
     /**


### PR DESCRIPTION
- does not implement promotion in `ResetPasswordToken` - will be done in separate PR

- [x] make "public" classes final (e.g. `Helper`) in 1.x as some property names will change because of this PR