### PR TITLE
[command] use `AsCommand` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ find a change that break's semver, please create an issue.*
 ### Feature
 
 - [#298](https://github.com/symfonycasts/reset-password-bundle/pull/298) - replace final annotation with final class keyword - *@jrushlow*
+- [#295](https://github.com/symfonycasts/reset-password-bundle/pull/295) - [command] use `AsCommand` attribute - *@jrushlow*
 
 ## [v1.18.0](https://github.com/symfonycasts/reset-password-bundle/releases/tag/v1.18.0)
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -11,3 +11,5 @@ replaced with the `final` class keyword. Extending this class is not allowed.
 
 - Class became `@final` in `v1.22.0` and in `v2.0.0` the `@final` annotation was
     replaced with the `final` class keyword. Extending this class is not allowed.
+
+- Command is now registered using the Symfony `#[AsCommand]` attribute

--- a/src/Command/ResetPasswordRemoveExpiredCommand.php
+++ b/src/Command/ResetPasswordRemoveExpiredCommand.php
@@ -9,6 +9,7 @@
 
 namespace SymfonyCasts\Bundle\ResetPassword\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -18,17 +19,13 @@ use SymfonyCasts\Bundle\ResetPassword\Util\ResetPasswordCleaner;
  * @author Jesse Rushlow <jr@rushlow.dev>
  * @author Ryan Weaver   <ryan@symfonycasts.com>
  */
+#[AsCommand(name: 'reset-password:remove-expired', description: 'Remove expired reset password requests from persistence.')]
 final class ResetPasswordRemoveExpiredCommand extends Command
 {
     public function __construct(
         private ResetPasswordCleaner $cleaner
     ) {
-        parent::__construct('reset-password:remove-expired');
-    }
-
-    protected function configure(): void
-    {
-        $this->setDescription('Remove expired reset password requests from persistence.');
+        parent::__construct();
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int


### PR DESCRIPTION
- set the command name and description using the `#[AsCommand]` Symfony attribute instead of using the `configure()` method / `__constructor()` argument