### PR TITLE
[command] make class final

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,3 +4,8 @@
 
 - Class became `@final` in `v1.22.0`. Extending this class will not be allowed
   in version `v2.0.0`.
+
+## ResetPasswordRemoveExpiredCommand
+
+- Class became `@final` in `v1.22.0`. Extending this class will not be allowed
+  in version `v2.0.0`.

--- a/src/Command/ResetPasswordRemoveExpiredCommand.php
+++ b/src/Command/ResetPasswordRemoveExpiredCommand.php
@@ -17,6 +17,8 @@ use SymfonyCasts\Bundle\ResetPassword\Util\ResetPasswordCleaner;
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
  * @author Ryan Weaver   <ryan@symfonycasts.com>
+ *
+ * @final
  */
 class ResetPasswordRemoveExpiredCommand extends Command
 {


### PR DESCRIPTION
`ResetPasswordRemoveExpiredCommand::class` is now final via `@final` annotation. In version `v2.0.0` this annotation will be replaced with the `final` PHP keyword - preventing it from being extended.

If customization is needed, creating a new command in userland is recommended.

refs #290