### PR TITLE
[ResetPasswordHelper] class to become final

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,6 @@
+# Upgrade from 1.x to 2.0
+
+## ResetPasswordHelper
+
+- Class became `@final` in `v1.22.0`. Extending this class will not be allowed
+  in version `v2.0.0`.

--- a/src/ResetPasswordHelper.php
+++ b/src/ResetPasswordHelper.php
@@ -21,6 +21,8 @@ use SymfonyCasts\Bundle\ResetPassword\Util\ResetPasswordCleaner;
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
  * @author Ryan Weaver   <ryan@symfonycasts.com>
+ *
+ * @final
  */
 class ResetPasswordHelper implements ResetPasswordHelperInterface
 {


### PR DESCRIPTION
`ResetPasswordHelper::class` is now final via `@final` annotation. In version `v2.0.0` this annotation will be replaced with the `final` PHP keyword - preventing it from being extended.

If customization is needed, creating a new helper in userland is recommended.

refs #290