### PR TITLE
[trait] remove deprecated methods in `ResetPasswordControllerTrait`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ find a change that break's semver, please create an issue.*
 
 ### Feature
 
+- [#301](https://github.com/symfonycasts/reset-password-bundle/pull/301) - [trait] remove deprecated methods `ReserPasswordControllerTrait` - *@jrushlow*
 - [#300](https://github.com/symfonycasts/reset-password-bundle/pull/300) - [interface] change `generateResetToken()` signature - *@jrushlow*
 - [#298](https://github.com/symfonycasts/reset-password-bundle/pull/298) - replace final annotation with final class keyword - *@jrushlow*
 - [#295](https://github.com/symfonycasts/reset-password-bundle/pull/295) - [command] use `AsCommand` attribute - *@jrushlow*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ find a change that break's semver, please create an issue.*
 
 ### Feature
 
-- [#301](https://github.com/symfonycasts/reset-password-bundle/pull/301) - [trait] remove deprecated methods `ReserPasswordControllerTrait` - *@jrushlow*
+- [#302](https://github.com/symfonycasts/reset-password-bundle/pull/302) - [trait] remove deprecated methods `ReserPasswordControllerTrait` - *@jrushlow*
 - [#300](https://github.com/symfonycasts/reset-password-bundle/pull/300) - [interface] change `generateResetToken()` signature - *@jrushlow*
 - [#298](https://github.com/symfonycasts/reset-password-bundle/pull/298) - replace final annotation with final class keyword - *@jrushlow*
 - [#295](https://github.com/symfonycasts/reset-password-bundle/pull/295) - [command] use `AsCommand` attribute - *@jrushlow*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ find a change that break's semver, please create an issue.*
 
 ### Feature
 
-- [#302](https://github.com/symfonycasts/reset-password-bundle/pull/302) - [trait] remove deprecated methods `ReserPasswordControllerTrait` - *@jrushlow*
+- [#302](https://github.com/symfonycasts/reset-password-bundle/pull/302) - [trait] remove deprecated methods in `ReserPasswordControllerTrait` - *@jrushlow*
 - [#300](https://github.com/symfonycasts/reset-password-bundle/pull/300) - [interface] change `generateResetToken()` signature - *@jrushlow*
 - [#298](https://github.com/symfonycasts/reset-password-bundle/pull/298) - replace final annotation with final class keyword - *@jrushlow*
 - [#295](https://github.com/symfonycasts/reset-password-bundle/pull/295) - [command] use `AsCommand` attribute - *@jrushlow*

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -23,3 +23,9 @@ replaced with the `final` class keyword. Extending this class is not allowed.
     replaced with the `final` class keyword. Extending this class is not allowed.
 
 - Command is now registered using the Symfony `#[AsCommand]` attribute
+
+## ResetPasswordControllerTrait
+
+- Removed deprecated `setCanCheckEmailInSession()` method from trait.
+
+- Removed deprecated `canCheckEmail()` method from trait.

--- a/src/Controller/ResetPasswordControllerTrait.php
+++ b/src/Controller/ResetPasswordControllerTrait.php
@@ -24,34 +24,6 @@ use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordToken;
  */
 trait ResetPasswordControllerTrait
 {
-    /**
-     * @deprecated since 1.3.0, use ResetPasswordControllerTrait::setTokenObjectInSession() instead.
-     */
-    private function setCanCheckEmailInSession(): void
-    {
-        trigger_deprecation(
-            'symfonycasts/reset-password-bundle',
-            '1.3.0',
-            'Storing the ResetPasswordToken object in the session is more desirable, use ResetPasswordControllerTrait::setTokenObjectInSession() instead.'
-        );
-
-        $this->getSessionService()->set('ResetPasswordCheckEmail', true);
-    }
-
-    /**
-     * @deprecated since 1.3.0, use ResetPasswordControllerTrait::getTokenObjectFromSession() instead.
-     */
-    private function canCheckEmail(): bool
-    {
-        trigger_deprecation(
-            'symfonycasts/reset-password-bundle',
-            '1.3.0',
-            'Storing the ResetPasswordToken object in the session is more desirable, use ResetPasswordControllerTrait::getTokenObjectFromSession() instead.'
-        );
-
-        return $this->getSessionService()->has('ResetPasswordCheckEmail');
-    }
-
     private function storeTokenInSession(string $token): void
     {
         $this->getSessionService()->set('ResetPasswordPublicToken', $token);

--- a/tests/Unit/Controller/ResetPasswordControllerTraitTest.php
+++ b/tests/Unit/Controller/ResetPasswordControllerTraitTest.php
@@ -28,10 +28,7 @@ class ResetPasswordControllerTraitTest extends TestCase
     private const TOKEN_KEY = 'ResetPasswordPublicToken';
     private const TOKEN_OBJECT_KEY = 'ResetPasswordToken';
 
-    /**
-     * @var MockObject|SessionInterface
-     */
-    private $mockSession;
+    private MockObject&SessionInterface $mockSession;
 
     protected function setUp(): void
     {
@@ -61,37 +58,6 @@ class ResetPasswordControllerTraitTest extends TestCase
 
         $fixture = $this->getFixture();
         $fixture->getToken();
-    }
-
-    /**
-     * @group legacy
-     */
-    public function testSetsEmailFlagInSession(): void
-    {
-        $this->mockSession
-            ->expects($this->once())
-            ->method('set')
-            ->with(self::EMAIL_KEY)
-        ;
-
-        $fixture = $this->getFixture();
-        $fixture->setEmail();
-    }
-
-    /**
-     * @group legacy
-     */
-    public function testCanCheckEmailUsesCorrectKey(): void
-    {
-        $this->mockSession
-            ->expects($this->once())
-            ->method('has')
-            ->with(self::EMAIL_KEY)
-            ->willReturn(true)
-        ;
-
-        $fixture = $this->getFixture();
-        $fixture->getEmail();
     }
 
     public function testSetsResetTokenInSession(): void
@@ -137,10 +103,7 @@ class ResetPasswordControllerTraitTest extends TestCase
         $fixture->clearSession();
     }
 
-    /**
-     * @return MockObject|ContainerInterface
-     */
-    private function getConfiguredMockContainer()
+    private function getConfiguredMockContainer(): MockObject&ContainerInterface
     {
         $mockRequest = $this->createMock(Request::class);
         $mockRequest
@@ -179,16 +142,6 @@ class ResetPasswordControllerTraitTest extends TestCase
             public function __construct(ContainerInterface $container)
             {
                 $this->container = $container;
-            }
-
-            public function setEmail(): void
-            {
-                $this->setCanCheckEmailInSession();
-            }
-
-            public function getEmail(): bool
-            {
-                return $this->canCheckEmail();
             }
 
             public function storeToken(string $token): void


### PR DESCRIPTION
- Removed deprecated `setCanCheckEmailInSession()` method from trait.

- Removed deprecated `canCheckEmail()` method from trait.