### PR TITLE
[trait] remove annotation support for ResetPasswordRequest objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ find a change that break's semver, please create an issue.*
 
 ### Feature
 
+- [#303](https://github.com/symfonycasts/reset-password-bundle/pull/303) - [trait] remove annotation support for ResetPasswordRequest objects - *@jrushlow*
 - [#302](https://github.com/symfonycasts/reset-password-bundle/pull/302) - [trait] remove deprecated methods in `ReserPasswordControllerTrait` - *@jrushlow*
 - [#300](https://github.com/symfonycasts/reset-password-bundle/pull/300) - [interface] change `generateResetToken()` signature - *@jrushlow*
 - [#298](https://github.com/symfonycasts/reset-password-bundle/pull/298) - replace final annotation with final class keyword - *@jrushlow*

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -29,3 +29,8 @@ replaced with the `final` class keyword. Extending this class is not allowed.
 - Removed deprecated `setCanCheckEmailInSession()` method from trait.
 
 - Removed deprecated `canCheckEmail()` method from trait.
+
+## ResetPasswordRequestTrait
+
+- Annotation support for ResetPasswordRequest Doctrine entities that use the
+trait has been dropped - attribute mapping is required.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -22,7 +22,7 @@ replaced with the `final` class keyword. Extending this class is not allowed.
 - Class became `@final` in `v1.22.0` and in `v2.0.0` the `@final` annotation was
     replaced with the `final` class keyword. Extending this class is not allowed.
 
-- Command is now registered using the Symfony `#[AsCommand]` attribute
+- Command is now registered using the Symfony `#[AsCommand]` attribute.
 
 ## ResetPasswordControllerTrait
 
@@ -34,3 +34,26 @@ replaced with the `final` class keyword. Extending this class is not allowed.
 
 - Annotation support for ResetPasswordRequest Doctrine entities that use the
 trait has been dropped - attribute mapping is required.
+
+- Property types were added to `selector`, `hashedToken`, `requestedAt`, & `expiresAt`.
+
+```diff
+- protected $selector;
++ protected string $selector;
+
+- protected $hashedToken;
++ protected string $hashedToken;
+
+- protected $requestedAt;
++ protected \DateTimeImmutable $requestedAt;
+
+- protected $expiresAt;
++ protected \DateTimeInterface $expiresAt;
+```
+
+- `initalize()` now returns `void`. Previously the return type was not declared
+
+```diff
+- protected function initialize(....)
++ protected function initialize(....): void
+```

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
         "symfony/framework-bundle": "^6.4.5 | ^7.0",
         "symfony/phpunit-bridge": "^6.4.5 | ^7.0",
         "doctrine/doctrine-bundle": "^2.8",
-        "doctrine/annotations": "^1.0",
         "phpstan/phpstan": "^1.11.x-dev"
     },
     "autoload": {

--- a/src/Model/ResetPasswordRequestTrait.php
+++ b/src/Model/ResetPasswordRequestTrait.php
@@ -18,40 +18,19 @@ use Doctrine\ORM\Mapping as ORM;
  */
 trait ResetPasswordRequestTrait
 {
-    /**
-     * @var string
-     *
-     * @ORM\Column(type="string", length=20)
-     */
     #[ORM\Column(type: Types::STRING, length: 20)]
-    protected $selector;
+    protected string $selector;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(type="string", length=100)
-     */
     #[ORM\Column(type: Types::STRING, length: 100)]
-    protected $hashedToken;
+    protected string $hashedToken;
 
-    /**
-     * @var \DateTimeImmutable
-     *
-     * @ORM\Column(type="datetime_immutable")
-     */
     #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
-    protected $requestedAt;
+    protected \DateTimeImmutable $requestedAt;
 
-    /**
-     * @var \DateTimeInterface
-     *
-     * @ORM\Column(type="datetime_immutable")
-     */
     #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
-    protected $expiresAt;
+    protected \DateTimeInterface $expiresAt;
 
-    /** @return void */
-    protected function initialize(\DateTimeInterface $expiresAt, string $selector, string $hashedToken)
+    protected function initialize(\DateTimeInterface $expiresAt, string $selector, string $hashedToken): void
     {
         $this->requestedAt = new \DateTimeImmutable('now');
         $this->expiresAt = $expiresAt;

--- a/tests/Fixtures/Entity/ResetPasswordTestFixtureRequest.php
+++ b/tests/Fixtures/Entity/ResetPasswordTestFixtureRequest.php
@@ -17,45 +17,24 @@ use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordRequestInterface;
  * @author Ryan Weaver   <ryan@symfonycasts.com>
  *
  * @internal
- *
- * @ORM\Entity(repositoryClass="SymfonyCasts\Bundle\ResetPassword\Tests\Fixtures\ResetPasswordTestFixtureRequestRepository")
  */
 #[ORM\Entity(repositoryClass: "SymfonyCasts\Bundle\ResetPassword\Tests\Fixtures\ResetPasswordTestFixtureRequestRepository")]
 final class ResetPasswordTestFixtureRequest implements ResetPasswordRequestInterface
 {
-    /**
-     * @ORM\Id()
-     *
-     * @ORM\GeneratedValue()
-     *
-     * @ORM\Column(type="integer")
-     */
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]
     public $id;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     */
     #[ORM\Column(type: 'string', nullable: true)]
     public $selector;
 
-    /**
-     * @ORM\Column(type="datetime_immutable", nullable=true)
-     */
     #[ORM\Column(type: 'datetime_immutable', nullable: true)]
     public $expiresAt;
 
-    /**
-     * @ORM\Column(type="datetime_immutable", nullable=true)
-     */
     #[ORM\Column(type: 'datetime_immutable', nullable: true)]
     public $requestedAt;
 
-    /**
-     * @ORM\ManyToOne(targetEntity="ResetPasswordTestFixtureUser")
-     */
     #[ORM\ManyToOne(targetEntity: 'ResetPasswordTestFixtureUser')]
     public $user;
 

--- a/tests/Fixtures/Entity/ResetPasswordTestFixtureUser.php
+++ b/tests/Fixtures/Entity/ResetPasswordTestFixtureUser.php
@@ -16,19 +16,10 @@ use Doctrine\ORM\Mapping as ORM;
  * @author Ryan Weaver   <ryan@symfonycasts.com>
  *
  * @internal
- *
- * @ORM\Entity()
  */
 #[ORM\Entity]
 final class ResetPasswordTestFixtureUser
 {
-    /**
-     * @ORM\Id()
-     *
-     * @ORM\GeneratedValue()
-     *
-     * @ORM\Column(type="integer")
-     */
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]

--- a/tests/ResetPasswordTestKernel.php
+++ b/tests/ResetPasswordTestKernel.php
@@ -87,7 +87,7 @@ class ResetPasswordTestKernel extends Kernel
                 ],
                 'orm' => [
                     'auto_generate_proxy_classes' => true,
-                    'auto_mapping' => false,
+                    'auto_mapping' => true,
                     'mappings' => [
                         'App' => [
                             'is_bundle' => false,

--- a/tests/ResetPasswordTestKernel.php
+++ b/tests/ResetPasswordTestKernel.php
@@ -87,11 +87,11 @@ class ResetPasswordTestKernel extends Kernel
                 ],
                 'orm' => [
                     'auto_generate_proxy_classes' => true,
-                    'auto_mapping' => true,
+                    'auto_mapping' => false,
                     'mappings' => [
                         'App' => [
                             'is_bundle' => false,
-                            'type' => self::shouldUseAttributes() ? 'attribute' : 'annotation',
+                            'type' => 'attribute',
                             'dir' => 'tests/Fixtures/Entity/',
                             'prefix' => 'SymfonyCasts\Bundle\ResetPassword\Tests\Fixtures\Entity',
                             'alias' => 'App',
@@ -140,10 +140,5 @@ class ResetPasswordTestKernel extends Kernel
     public function getLogDir(): string
     {
         return sys_get_temp_dir().'/logs'.spl_object_hash($this);
-    }
-
-    public static function shouldUseAttributes(): bool
-    {
-        return Kernel::VERSION_ID >= 70000;
     }
 }

--- a/tests/ResetPasswordTestKernel.php
+++ b/tests/ResetPasswordTestKernel.php
@@ -87,7 +87,8 @@ class ResetPasswordTestKernel extends Kernel
                 ],
                 'orm' => [
                     'auto_generate_proxy_classes' => true,
-                    'auto_mapping' => false,
+                    'controller_resolver' => ['auto_mapping' => false], // @see https://github.com/doctrine/DoctrineBundle/pull/1762
+                    'enable_lazy_ghost_objects' => true, // @see https://github.com/doctrine/DoctrineBundle/pull/1733
                     'mappings' => [
                         'App' => [
                             'is_bundle' => false,
@@ -97,6 +98,7 @@ class ResetPasswordTestKernel extends Kernel
                             'alias' => 'App',
                         ],
                     ],
+                    'report_fields_where_declared' => true,  // @see https://github.com/doctrine/DoctrineBundle/pull/1661
                 ],
             ]);
 

--- a/tests/ResetPasswordTestKernel.php
+++ b/tests/ResetPasswordTestKernel.php
@@ -87,8 +87,7 @@ class ResetPasswordTestKernel extends Kernel
                 ],
                 'orm' => [
                     'auto_generate_proxy_classes' => true,
-                    'controller_resolver' => ['auto_mapping' => false], // @see https://github.com/doctrine/DoctrineBundle/pull/1762
-                    'enable_lazy_ghost_objects' => true, // @see https://github.com/doctrine/DoctrineBundle/pull/1733
+                    'auto_mapping' => false,
                     'mappings' => [
                         'App' => [
                             'is_bundle' => false,
@@ -98,7 +97,6 @@ class ResetPasswordTestKernel extends Kernel
                             'alias' => 'App',
                         ],
                     ],
-                    'report_fields_where_declared' => true,  // @see https://github.com/doctrine/DoctrineBundle/pull/1661
                 ],
             ]);
 


### PR DESCRIPTION
- removes doctrine annotations in the `ResetPasswordRequestTrait`. As a result, attribute mapping is required when using the trait for `ResetPasswordRequest` entities.

- adds property types for class properties

- add the `void` return type to `initialize()`

- [x] replaces annotations added to 1.x in #305 
- [x] app test locally