### PR TITLE
[token] add types and constructor property promotion

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -75,6 +75,22 @@ is no longer allowed. The argument is also now mandatory.
 + public function __construct(string $token, \DateTimeInterface $expiresAt, int $generatedAt)
 ```
 
+- Property types were added to `token`, `expiresAt`, `generatedAt`.
+
+```diff
+- private $token;
++ private ?string $token;
+
+- private $expiresAt;
++ private \DateTimeInterface $expiresAt;
+
+- private $generatedAt;
++ private int $generatedAt;
+```
+
+_Note: When calling `ResetPasswordToken::clearToken()`, the value of `$token` is set to `null`. It is not possible to 
+instantiate a token object with a `null` `$token` value. This is intentional._
+
 ## ResetPasswordTokenGenerator
 
 - Type added for `createToken()`'s `$userId` argument

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -67,6 +67,14 @@ trait has been dropped - attribute mapping is required.
   no longer potentially throw a `LogicException`. They now throw a `ResetPasswordRuntimeException`
   if an invalid `$generatedAt` timestamp is provided to the class constructor.
 
+- Passing `null` for the `$generatedAt` argument when instantiating a new token object
+is no longer allowed. The argument is also now mandatory.
+
+```diff
+- public function __construct(string $token, \DateTimeInterface $expiresAt, ?int $generatedAt = null)
++ public function __construct(string $token, \DateTimeInterface $expiresAt, int $generatedAt)
+```
+
 ## ResetPasswordTokenGenerator
 
 - Type added for `createToken()`'s `$userId` argument

--- a/src/Model/ResetPasswordToken.php
+++ b/src/Model/ResetPasswordToken.php
@@ -28,24 +28,20 @@ final class ResetPasswordToken
     private $expiresAt;
 
     /**
-     * @var int|null timestamp when the token was created
+     * @var int timestamp when the token was created
      */
-    private $generatedAt;
+    private int $generatedAt;
 
     /**
      * @var int expiresAt translator interval
      */
     private $transInterval = 0;
 
-    public function __construct(string $token, \DateTimeInterface $expiresAt, ?int $generatedAt = null)
+    public function __construct(string $token, \DateTimeInterface $expiresAt, int $generatedAt)
     {
         $this->token = $token;
         $this->expiresAt = $expiresAt;
         $this->generatedAt = $generatedAt;
-
-        if (null === $generatedAt) {
-            $this->triggerDeprecation();
-        }
     }
 
     /**
@@ -138,10 +134,6 @@ final class ResetPasswordToken
      */
     public function getExpiresAtIntervalInstance(): \DateInterval
     {
-        if (null === $this->generatedAt) {
-            throw new \LogicException(sprintf('%s initialized without setting the $generatedAt timestamp.', self::class));
-        }
-
         $createdAtTime = \DateTimeImmutable::createFromFormat('U', (string) $this->generatedAt);
 
         if (false === $createdAtTime) {
@@ -149,18 +141,5 @@ final class ResetPasswordToken
         }
 
         return $this->expiresAt->diff($createdAtTime);
-    }
-
-    /**
-     * @psalm-suppress UndefinedFunction
-     */
-    private function triggerDeprecation(): void
-    {
-        trigger_deprecation(
-            'symfonycasts/reset-password-bundle',
-            '1.2',
-            'Initializing the %s without setting the "$generatedAt" constructor argument is deprecated. The default "null" will be removed in the future.',
-            self::class
-        );
     }
 }

--- a/src/Model/ResetPasswordToken.php
+++ b/src/Model/ResetPasswordToken.php
@@ -17,31 +17,23 @@ use SymfonyCasts\Bundle\ResetPassword\Exception\ResetPasswordRuntimeException;
  */
 final class ResetPasswordToken
 {
-    /**
-     * @var string|null selector + non-hashed verifier token
-     */
-    private $token;
-
-    /**
-     * @var \DateTimeInterface
-     */
-    private $expiresAt;
-
-    /**
-     * @var int timestamp when the token was created
-     */
-    private int $generatedAt;
+    private ?string $token;
 
     /**
      * @var int expiresAt translator interval
      */
-    private $transInterval = 0;
+    private int $transInterval = 0;
 
-    public function __construct(string $token, \DateTimeInterface $expiresAt, int $generatedAt)
-    {
+    /**
+     * @param string $token       selector + non-hashed verifier token
+     * @param int    $generatedAt timestamp when the token was created
+     */
+    public function __construct(
+        string $token,
+        private \DateTimeInterface $expiresAt,
+        private int $generatedAt
+    ) {
         $this->token = $token;
-        $this->expiresAt = $expiresAt;
-        $this->generatedAt = $generatedAt;
     }
 
     /**


### PR DESCRIPTION
- replaces type annotations with property types
- implements constructor property promotion where possible
- requires an `int` to be passed to the now mandatory `$generatedAt` argument when instantiating a new object. The ability to Omit or pass `null` to `$generatedAt` has been deprecated since `v1.2`