### PR TITLE
[token] throws ResetPasswordRuntimeException

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -57,3 +57,12 @@ trait has been dropped - attribute mapping is required.
 - protected function initialize(....)
 + protected function initialize(....): void
 ```
+
+## ResetPasswordToken
+
+- Method `getToken()` now throws a `ResetPasswordRuntimeException` instead of a
+`\RuntimeException` if the `clearToken()` method has been previously called. 
+
+- Method's `getExpirationMessageKey`, `getExpirationMessageData`, & `getExpiresAtIntervalInstance`
+  no longer potentially throw a `LogicException`. They now throw a `ResetPasswordRuntimeException`
+  if an invalid `$generatedAt` timestamp is provided to the class constructor.

--- a/src/Exception/ResetPasswordRuntimeException.php
+++ b/src/Exception/ResetPasswordRuntimeException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the SymfonyCasts ResetPasswordBundle package.
+ * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SymfonyCasts\Bundle\ResetPassword\Exception;
+
+/**
+ * @author Jesse Rushlow <jr@rushlow.dev>
+ */
+final class ResetPasswordRuntimeException extends \RuntimeException implements ResetPasswordExceptionInterface
+{
+    public function getReason(): string
+    {
+        return $this->getMessage();
+    }
+}

--- a/src/Model/ResetPasswordToken.php
+++ b/src/Model/ResetPasswordToken.php
@@ -9,6 +9,8 @@
 
 namespace SymfonyCasts\Bundle\ResetPassword\Model;
 
+use SymfonyCasts\Bundle\ResetPassword\Exception\ResetPasswordRuntimeException;
+
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
  * @author Ryan Weaver   <ryan@symfonycasts.com>
@@ -52,11 +54,13 @@ final class ResetPasswordToken
      * Internally, this consists of two parts - the selector and
      * the hashed token - but that's an implementation detail
      * of how the token will later be parsed.
+     *
+     * @throws ResetPasswordRuntimeException
      */
     public function getToken(): string
     {
         if (null === $this->token) {
-            throw new \RuntimeException('The token property is not set. Calling getToken() after calling clearToken() is not allowed.');
+            throw new ResetPasswordRuntimeException('The token property is not set. Calling getToken() after calling clearToken() is not allowed.');
         }
 
         return $this->token;
@@ -85,7 +89,7 @@ final class ResetPasswordToken
      *
      * symfony/translation is required to translate into a non-English locale.
      *
-     * @throws \LogicException
+     * @throws ResetPasswordRuntimeException
      */
     public function getExpirationMessageKey(): string
     {
@@ -118,7 +122,7 @@ final class ResetPasswordToken
     /**
      * @return array<string, int>
      *
-     * @throws \LogicException
+     * @throws ResetPasswordRuntimeException
      */
     public function getExpirationMessageData(): array
     {
@@ -130,9 +134,7 @@ final class ResetPasswordToken
     /**
      * Get the interval that the token is valid for.
      *
-     * @throws \LogicException
-     *
-     * @psalm-suppress PossiblyFalseArgument
+     * @throws ResetPasswordRuntimeException
      */
     public function getExpiresAtIntervalInstance(): \DateInterval
     {
@@ -141,6 +143,10 @@ final class ResetPasswordToken
         }
 
         $createdAtTime = \DateTimeImmutable::createFromFormat('U', (string) $this->generatedAt);
+
+        if (false === $createdAtTime) {
+            throw new ResetPasswordRuntimeException(sprintf('Unable to create DateTimeInterface instance from "generatedAt": %s', $this->generatedAt));
+        }
 
         return $this->expiresAt->diff($createdAtTime);
     }


### PR DESCRIPTION
- `getToken()` now throws a `ResetPasswordRuntimeException` instead of a `\RuntimeException`

- `getExpirationMessageKey()`, `getExpirationMessageData()`, & `getExpiresAtIntervalInstance()` now throw a `ResetPasswordRuntimeException` if an invalid timestamp was passed for `$generatedAt`. Previously, an unknown
exception may have been thrown if `DateTimeImmutable::createFromFormat()` returned `false` instead of a time object.

- the `LogicException` annotation (completely unrelated to this PR) was replaced as it is being removed in #307