### PR TITLE
[generator] [1.x] userId argument should be either a string or int

### DIFF
--- a/src/Generator/ResetPasswordTokenGenerator.php
+++ b/src/Generator/ResetPasswordTokenGenerator.php
@@ -40,8 +40,8 @@ class ResetPasswordTokenGenerator
     /**
      * Get a cryptographically secure token with it's non-hashed components.
      *
-     * @param mixed  $userId   Unique user identifier
-     * @param string $verifier Only required for token comparison
+     * @param int|string  $userId   Unique user identifier
+     * @param ?string $verifier Only required for token comparison
      */
     public function createToken(\DateTimeInterface $expiresAt, $userId, ?string $verifier = null): ResetPasswordTokenComponents
     {

--- a/src/Generator/ResetPasswordTokenGenerator.php
+++ b/src/Generator/ResetPasswordTokenGenerator.php
@@ -40,8 +40,8 @@ class ResetPasswordTokenGenerator
     /**
      * Get a cryptographically secure token with it's non-hashed components.
      *
-     * @param int|string  $userId   Unique user identifier
-     * @param ?string $verifier Only required for token comparison
+     * @param int|string $userId   Unique user identifier
+     * @param ?string    $verifier Only required for token comparison
      */
     public function createToken(\DateTimeInterface $expiresAt, $userId, ?string $verifier = null): ResetPasswordTokenComponents
     {


### PR DESCRIPTION
- fixes annotation for `$verifier` - missing `null` type

- changes the `$userId` type annotation from `mixed` to `int|string`. In `v2.0` the argument type `int|string` will be added.

_Merge as feature for changelog visibility in release_