### PR TITLE
[generator] add argument type for userId

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -66,3 +66,12 @@ trait has been dropped - attribute mapping is required.
 - Method's `getExpirationMessageKey`, `getExpirationMessageData`, & `getExpiresAtIntervalInstance`
   no longer potentially throw a `LogicException`. They now throw a `ResetPasswordRuntimeException`
   if an invalid `$generatedAt` timestamp is provided to the class constructor.
+
+## ResetPasswordTokenGenerator
+
+- Type added for `createToken()`'s `$userId` argument
+
+```diff
+- public function createToken(\DateTimeInterface $expiresAt, $userId, ?string $verifier = null): ResetPasswordTokenComponents
++ public function createToken(\DateTimeInterface $expiresAt, int|string $userId, ?string $verifier = null): ResetPasswordTokenComponents
+```

--- a/src/Generator/ResetPasswordTokenGenerator.php
+++ b/src/Generator/ResetPasswordTokenGenerator.php
@@ -36,7 +36,7 @@ class ResetPasswordTokenGenerator
      * @param int|string $userId   Unique user identifier
      * @param ?string    $verifier Only required for token comparison
      */
-    public function createToken(\DateTimeInterface $expiresAt, $userId, ?string $verifier = null): ResetPasswordTokenComponents
+    public function createToken(\DateTimeInterface $expiresAt, int|string $userId, ?string $verifier = null): ResetPasswordTokenComponents
     {
         if (null === $verifier) {
             $verifier = $this->generator->getRandomAlphaNumStr();


### PR DESCRIPTION
- adds  `int|string` type for `createToken($userId)`. Previously no type was declared, but `mixed` was annotated in the method docBlock. In #310, `mixed` was changed to `int|string`.

- [x] depends on #310