### PR TITLE
[ci] fix wrong tmp path in php-cs-fixer config

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -7,7 +7,7 @@ if (!file_exists(__DIR__.'/src') || !file_exists(__DIR__.'/tests')) {
 $finder = (new PhpCsFixer\Finder())
     ->in([__DIR__.'/src', __DIR__.'/tests'])
     ->exclude([
-        __DIR__.'tests/tmp'
+        'tmp'
     ])
 ;
 


### PR DESCRIPTION
finder `exclude` paths must be relative to the `in` paths. This prevents php-cs-fixer from attempting to scan/fix files in `tests/tmp/cache/etc...`