### PR TITLE
Replacing Static Fake Token with Randomized 32-Character Token

### DIFF
--- a/src/ResetPasswordHelper.php
+++ b/src/ResetPasswordHelper.php
@@ -168,7 +168,9 @@ class ResetPasswordHelper implements ResetPasswordHelperInterface
 
         $generatedAt = ($expiresAt->getTimestamp() - $resetRequestLifetime);
 
-        return new ResetPasswordToken('fake-token', $expiresAt, $generatedAt);
+        $fakeToken = bin2hex(random_bytes(16));
+
+        return new ResetPasswordToken($fakeToken, $expiresAt, $generatedAt);
     }
 
     private function findResetPasswordRequest(string $token): ?ResetPasswordRequestInterface


### PR DESCRIPTION
The `generateFakeResetToken()` method previously used a static string (`'fake-token'`) as a placeholder for the fake token. This PR updates it to generate a randomized 32-character hexadecimal string using `bin2hex(random_bytes(16))`. This change improves the security and realism of the fake token by mimicking the structure and appearance of a real token.