### PR TITLE
Use Clock instead of DateTime

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
     "require": {
         "php": ">=8.1.10",
         "symfony/config": "^5.4 | ^6.0 | ^7.0 | ^8.0",
+        "symfony/clock": "^6.3 | ^7.0 | ^8.0",
         "symfony/dependency-injection": "^5.4 | ^6.0 | ^7.0 | ^8.0",
         "symfony/deprecation-contracts": "^2.2 | ^3.0",
         "symfony/http-kernel": "^5.4 | ^6.0 | ^7.0 | ^8.0"

--- a/src/Exception/TooManyPasswordRequestsException.php
+++ b/src/Exception/TooManyPasswordRequestsException.php
@@ -9,6 +9,8 @@
 
 namespace SymfonyCasts\Bundle\ResetPassword\Exception;
 
+use Symfony\Component\Clock\Clock;
+
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
  */
@@ -30,7 +32,7 @@ final class TooManyPasswordRequestsException extends \Exception implements Reset
 
     public function getRetryAfter(): int
     {
-        return $this->getAvailableAt()->getTimestamp() - (new \DateTime('now'))->getTimestamp();
+        return $this->getAvailableAt()->getTimestamp() - Clock::get()->now()->getTimestamp();
     }
 
     public function getReason(): string

--- a/src/Model/ResetPasswordRequestTrait.php
+++ b/src/Model/ResetPasswordRequestTrait.php
@@ -11,6 +11,7 @@ namespace SymfonyCasts\Bundle\ResetPassword\Model;
 
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Clock\Clock;
 
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
@@ -53,7 +54,7 @@ trait ResetPasswordRequestTrait
     /** @return void */
     protected function initialize(\DateTimeInterface $expiresAt, string $selector, string $hashedToken)
     {
-        $this->requestedAt = new \DateTimeImmutable('now');
+        $this->requestedAt = Clock::get()->now();
         $this->expiresAt = $expiresAt;
         $this->selector = $selector;
         $this->hashedToken = $hashedToken;

--- a/src/Persistence/Repository/ResetPasswordRequestRepositoryTrait.php
+++ b/src/Persistence/Repository/ResetPasswordRequestRepositoryTrait.php
@@ -9,6 +9,7 @@
 
 namespace SymfonyCasts\Bundle\ResetPassword\Persistence\Repository;
 
+use Symfony\Component\Clock\Clock;
 use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordRequestInterface;
 
 /**
@@ -72,7 +73,7 @@ trait ResetPasswordRequestRepositoryTrait
 
     public function removeExpiredResetPasswordRequests(): int
     {
-        $time = new \DateTimeImmutable('-1 week');
+        $time = Clock::get()->now()->modify('-1 week');
         $query = $this->createQueryBuilder('t')
             ->delete()
             ->where('t.expiresAt <= :time')

--- a/src/ResetPasswordHelper.php
+++ b/src/ResetPasswordHelper.php
@@ -9,6 +9,7 @@
 
 namespace SymfonyCasts\Bundle\ResetPassword;
 
+use Symfony\Component\Clock\Clock;
 use SymfonyCasts\Bundle\ResetPassword\Exception\ExpiredResetPasswordTokenException;
 use SymfonyCasts\Bundle\ResetPassword\Exception\InvalidResetPasswordTokenException;
 use SymfonyCasts\Bundle\ResetPassword\Exception\TooManyPasswordRequestsException;
@@ -72,7 +73,7 @@ class ResetPasswordHelper implements ResetPasswordHelperInterface
 
         $resetRequestLifetime = $resetRequestLifetime ?? $this->resetRequestLifetime;
 
-        $expiresAt = new \DateTimeImmutable(\sprintf('+%d seconds', $resetRequestLifetime));
+        $expiresAt = Clock::get()->now()->modify(\sprintf('+%d seconds', $resetRequestLifetime));
 
         $generatedAt = ($expiresAt->getTimestamp() - $resetRequestLifetime);
 
@@ -164,7 +165,7 @@ class ResetPasswordHelper implements ResetPasswordHelperInterface
     public function generateFakeResetToken(?int $resetRequestLifetime = null): ResetPasswordToken
     {
         $resetRequestLifetime = $resetRequestLifetime ?? $this->resetRequestLifetime;
-        $expiresAt = new \DateTimeImmutable(\sprintf('+%d seconds', $resetRequestLifetime));
+        $expiresAt = Clock::get()->now()->modify(\sprintf('+%d seconds', $resetRequestLifetime));
 
         $generatedAt = ($expiresAt->getTimestamp() - $resetRequestLifetime);
 
@@ -191,7 +192,7 @@ class ResetPasswordHelper implements ResetPasswordHelperInterface
 
         $availableAt = (clone $lastRequestDate)->add(new \DateInterval("PT{$this->requestThrottleTime}S"));
 
-        if ($availableAt > new \DateTime('now')) {
+        if ($availableAt > Clock::get()->now()) {
             return $availableAt;
         }
 


### PR DESCRIPTION
Hi @bocharsky-bw 

I'm using Clock in my project, and getting weird behavior while testing the reset password feature because it doesn't rely on it. I think this behavior is BC since by default `now()` returns `new DateTimeImmutable()`. This will allow to mock the clock in tests.