### PR TITLE
Use clock over time()

### DIFF
--- a/src/Model/ResetPasswordRequestTrait.php
+++ b/src/Model/ResetPasswordRequestTrait.php
@@ -67,7 +67,7 @@ trait ResetPasswordRequestTrait
 
     public function isExpired(): bool
     {
-        return $this->expiresAt->getTimestamp() <= time();
+        return $this->expiresAt->getTimestamp() <= Clock::get()->now()->getTimestamp();
     }
 
     public function getExpiresAt(): \DateTimeInterface


### PR DESCRIPTION
Hi @bocharsky-bw 

This complete https://github.com/SymfonyCasts/reset-password-bundle/pull/354
This add consistency, when mocking the time with the clock from Symfony.

I changed all the `new \Datetime` instance but forgot one `time()` call.