### PR TITLE
Use generics to precise User class

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16,26 +16,6 @@ parameters:
 			path: src/Model/ResetPasswordToken.php
 
 		-
-			message: "#^Property SymfonyCasts\\\\Bundle\\\\ResetPassword\\\\ResetPasswordHelper\\:\\:\\$repository has no type specified\\.$#"
-			count: 1
-			path: src/ResetPasswordHelper.php
-
-		-
-			message: "#^Property SymfonyCasts\\\\Bundle\\\\ResetPassword\\\\ResetPasswordHelper\\:\\:\\$resetPasswordCleaner has no type specified\\.$#"
-			count: 1
-			path: src/ResetPasswordHelper.php
-
-		-
-			message: "#^Property SymfonyCasts\\\\Bundle\\\\ResetPassword\\\\ResetPasswordHelper\\:\\:\\$tokenGenerator has no type specified\\.$#"
-			count: 1
-			path: src/ResetPasswordHelper.php
-
-		-
 			message: "#^PHPDoc tag @param references unknown parameter\\: \\$resetRequestLifetime$#"
 			count: 1
 			path: src/ResetPasswordHelperInterface.php
-
-		-
-			message: "#^Property SymfonyCasts\\\\Bundle\\\\ResetPassword\\\\Util\\\\ResetPasswordCleaner\\:\\:\\$repository has no type specified\\.$#"
-			count: 1
-			path: src/Util/ResetPasswordCleaner.php

--- a/src/Model/ResetPasswordRequestInterface.php
+++ b/src/Model/ResetPasswordRequestInterface.php
@@ -12,6 +12,8 @@ namespace SymfonyCasts\Bundle\ResetPassword\Model;
 /**
  * @author Jesse Rushlow <jr@rushlow.dev>
  * @author Ryan Weaver   <ryan@symfonycasts.com>
+ *
+ * @template TUser of object
  */
 interface ResetPasswordRequestInterface
 {
@@ -37,6 +39,8 @@ interface ResetPasswordRequestInterface
 
     /**
      * Get the user whom requested a password reset.
+     *
+     * @return TUser
      */
     public function getUser(): object;
 }

--- a/src/Persistence/Fake/FakeResetPasswordInternalRepository.php
+++ b/src/Persistence/Fake/FakeResetPasswordInternalRepository.php
@@ -22,6 +22,8 @@ use SymfonyCasts\Bundle\ResetPassword\Persistence\ResetPasswordRequestRepository
  * @author Jesse Rushlow <jr@rushlow.dev>
  * @author Ryan Weaver   <ryan@symfonycasts.com>
  *
+ * @implements ResetPasswordRequestRepositoryInterface<object>
+ *
  * @internal
  */
 final class FakeResetPasswordInternalRepository implements ResetPasswordRequestRepositoryInterface

--- a/src/Persistence/Repository/ResetPasswordRequestRepositoryTrait.php
+++ b/src/Persistence/Repository/ResetPasswordRequestRepositoryTrait.php
@@ -22,9 +22,14 @@ use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordRequestInterface;
  *
  * @author Jesse Rushlow <jr@rushlow.dev>
  * @author Ryan Weaver   <ryan@symfonycasts.com>
+ *
+ * @template TUser of object
  */
 trait ResetPasswordRequestRepositoryTrait
 {
+    /**
+     * @param TUser $user
+     */
     public function getUserIdentifier(object $user): string
     {
         return (string) $this->getEntityManager()
@@ -33,23 +38,32 @@ trait ResetPasswordRequestRepositoryTrait
         ;
     }
 
+    /**
+     * @param ResetPasswordRequestInterface<TUser> $resetPasswordRequest
+     */
     public function persistResetPasswordRequest(ResetPasswordRequestInterface $resetPasswordRequest): void
     {
         $this->getEntityManager()->persist($resetPasswordRequest);
         $this->getEntityManager()->flush();
     }
 
+    /**
+     * @return ResetPasswordRequestInterface<TUser>
+     */
     public function findResetPasswordRequest(string $selector): ?ResetPasswordRequestInterface
     {
         return $this->findOneBy(['selector' => $selector]);
     }
 
+    /**
+     * @param TUser $user
+     */
     public function getMostRecentNonExpiredRequestDate(object $user): ?\DateTimeInterface
     {
         $builder = $this->setUserParam($this->createQueryBuilder('t'), $user);
 
         // Normally there is only 1 max request per use, but written to be flexible
-        /** @var ResetPasswordRequestInterface $resetPasswordRequest */
+        /** @var ResetPasswordRequestInterface<TUser> $resetPasswordRequest */
         $resetPasswordRequest = $builder
             ->where('t.user = :user')
             ->orderBy('t.requestedAt', 'DESC')
@@ -65,6 +79,9 @@ trait ResetPasswordRequestRepositoryTrait
         return null;
     }
 
+    /**
+     * @param ResetPasswordRequestInterface<TUser> $resetPasswordRequest
+     */
     public function removeResetPasswordRequest(ResetPasswordRequestInterface $resetPasswordRequest): void
     {
         $builder = $this->setUserParam($this->createQueryBuilder('t'), $resetPasswordRequest->getUser());
@@ -98,6 +115,8 @@ trait ResetPasswordRequestRepositoryTrait
      * ResetPasswordRequests but have not "checked their email" yet.
      *
      * @see https://github.com/SymfonyCasts/reset-password-bundle?tab=readme-ov-file#advanced-usage
+     *
+     * @param TUser $user
      */
     public function removeRequests(object $user): void
     {

--- a/src/Persistence/ResetPasswordRequestRepositoryInterface.php
+++ b/src/Persistence/ResetPasswordRequestRepositoryInterface.php
@@ -15,6 +15,8 @@ use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordRequestInterface;
  * @author Jesse Rushlow <jr@rushlow.dev>
  * @author Ryan Weaver   <ryan@symfonycasts.com>
  *
+ * @template TUser of object
+ *
  * @method void removeRequests(object $user) Remove a users ResetPasswordRequest objects from persistence.
  */
 interface ResetPasswordRequestRepositoryInterface
@@ -25,18 +27,22 @@ interface ResetPasswordRequestRepositoryInterface
      * @param object $user        User entity - typically implements Symfony\Component\Security\Core\User\UserInterface
      * @param string $selector    A non-hashed random string used to fetch a request from persistence
      * @param string $hashedToken The hashed token used to verify a reset request
+     *
+     * @return ResetPasswordRequestInterface<TUser>
      */
     public function createResetPasswordRequest(object $user, \DateTimeInterface $expiresAt, string $selector, string $hashedToken): ResetPasswordRequestInterface;
 
     /**
      * Get the unique user entity identifier from persistence.
      *
-     * @param object $user User entity - typically implements Symfony\Component\Security\Core\User\UserInterface
+     * @param TUser $user User entity - typically implements Symfony\Component\Security\Core\User\UserInterface
      */
     public function getUserIdentifier(object $user): string;
 
     /**
      * Save a reset password request entity to persistence.
+     *
+     * @param ResetPasswordRequestInterface<TUser> $resetPasswordRequest
      */
     public function persistResetPasswordRequest(ResetPasswordRequestInterface $resetPasswordRequest): void;
 
@@ -44,13 +50,15 @@ interface ResetPasswordRequestRepositoryInterface
      * Get a reset password request entity from persistence, if one exists, using the request's selector.
      *
      * @param string $selector A non-hashed random string used to fetch a request from persistence
+     *
+     * @return ResetPasswordRequestInterface<TUser>|null
      */
     public function findResetPasswordRequest(string $selector): ?ResetPasswordRequestInterface;
 
     /**
      * Get the most recent non-expired reset password request date for the user, if one exists.
      *
-     * @param object $user User entity - typically implements Symfony\Component\Security\Core\User\UserInterface
+     * @param TUser $user User entity - typically implements Symfony\Component\Security\Core\User\UserInterface
      */
     public function getMostRecentNonExpiredRequestDate(object $user): ?\DateTimeInterface;
 
@@ -59,6 +67,8 @@ interface ResetPasswordRequestRepositoryInterface
      *
      * This method should remove this ResetPasswordRequestInterface and also all
      * other ResetPasswordRequestInterface objects in storage for the same user.
+     *
+     * @param ResetPasswordRequestInterface<TUser> $resetPasswordRequest
      */
     public function removeResetPasswordRequest(ResetPasswordRequestInterface $resetPasswordRequest): void;
 

--- a/src/ResetPasswordHelper.php
+++ b/src/ResetPasswordHelper.php
@@ -23,6 +23,10 @@ use SymfonyCasts\Bundle\ResetPassword\Util\ResetPasswordCleaner;
  * @author Jesse Rushlow <jr@rushlow.dev>
  * @author Ryan Weaver   <ryan@symfonycasts.com>
  *
+ * @template TUser of object
+ *
+ * @implements ResetPasswordHelperInterface<TUser>
+ *
  * @final
  */
 class ResetPasswordHelper implements ResetPasswordHelperInterface
@@ -32,8 +36,19 @@ class ResetPasswordHelper implements ResetPasswordHelperInterface
      */
     private const SELECTOR_LENGTH = 20;
 
+    /**
+     * @var ResetPasswordTokenGenerator
+     */
     private $tokenGenerator;
+
+    /**
+     * @var ResetPasswordCleaner
+     */
     private $resetPasswordCleaner;
+
+    /**
+     * @var ResetPasswordRequestRepositoryInterface<TUser>
+     */
     private $repository;
 
     /**
@@ -46,6 +61,9 @@ class ResetPasswordHelper implements ResetPasswordHelperInterface
      */
     private $requestThrottleTime;
 
+    /**
+     * @param ResetPasswordRequestRepositoryInterface<TUser> $repository
+     */
     public function __construct(ResetPasswordTokenGenerator $generator, ResetPasswordCleaner $cleaner, ResetPasswordRequestRepositoryInterface $repository, int $resetRequestLifetime, int $requestThrottleTime)
     {
         $this->tokenGenerator = $generator;
@@ -60,6 +78,8 @@ class ResetPasswordHelper implements ResetPasswordHelperInterface
      *
      * Some of the cryptographic strategies were taken from
      * https://paragonie.com/blog/2017/02/split-tokens-token-based-authentication-protocols-without-side-channels
+     *
+     * @param TUser $user
      *
      * @throws TooManyPasswordRequestsException
      */
@@ -97,6 +117,8 @@ class ResetPasswordHelper implements ResetPasswordHelperInterface
     }
 
     /**
+     * @return TUser
+     *
      * @throws ExpiredResetPasswordTokenException
      * @throws InvalidResetPasswordTokenException
      */
@@ -174,6 +196,9 @@ class ResetPasswordHelper implements ResetPasswordHelperInterface
         return new ResetPasswordToken($fakeToken, $expiresAt, $generatedAt);
     }
 
+    /**
+     * @return ResetPasswordRequestInterface<TUser>|null
+     */
     private function findResetPasswordRequest(string $token): ?ResetPasswordRequestInterface
     {
         $selector = substr($token, 0, self::SELECTOR_LENGTH);
@@ -181,6 +206,9 @@ class ResetPasswordHelper implements ResetPasswordHelperInterface
         return $this->repository->findResetPasswordRequest($selector);
     }
 
+    /**
+     * @param TUser $user
+     */
     private function hasUserHitThrottling(object $user): ?\DateTimeInterface
     {
         /** @var \DateTime|\DateTimeImmutable|null $lastRequestDate */

--- a/src/ResetPasswordHelperInterface.php
+++ b/src/ResetPasswordHelperInterface.php
@@ -16,6 +16,8 @@ use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordToken;
  * @author Jesse Rushlow <jr@rushlow.dev>
  * @author Ryan Weaver   <ryan@symfonycasts.com>
  *
+ * @template TUser of object
+ *
  * @method ResetPasswordToken generateFakeResetToken(?int $resetRequestLifetime = null) Generates a fake ResetPasswordToken.
  */
 interface ResetPasswordHelperInterface
@@ -42,6 +44,8 @@ interface ResetPasswordHelperInterface
      * a ResetPasswordExceptionInterface instance should be thrown.
      *
      * @param string $fullToken selector string + verifier string provided by the user
+     *
+     * @return TUser
      *
      * @throws ResetPasswordExceptionInterface
      */

--- a/src/Util/ResetPasswordCleaner.php
+++ b/src/Util/ResetPasswordCleaner.php
@@ -26,8 +26,14 @@ class ResetPasswordCleaner
      */
     private $enabled;
 
+    /**
+     * @var ResetPasswordRequestRepositoryInterface<object>
+     */
     private $repository;
 
+    /**
+     * @param ResetPasswordRequestRepositoryInterface<object> $repository
+     */
     public function __construct(ResetPasswordRequestRepositoryInterface $repository, bool $enabled = true)
     {
         $this->repository = $repository;


### PR DESCRIPTION
Hi @bocharsky-bw 

These generics are useful for static analysis like PHPStan or psalm, because it allows to precise the return type or the expected param of some methods (instead of a general object one).

The only failure is
```
1) src/Model/ResetPasswordRequestTrait.php
      ---------- begin diff ----------
--- /home/runner/work/reset-password-bundle/reset-password-bundle/src/Model/ResetPasswordRequestTrait.php
+++ /home/runner/work/reset-password-bundle/reset-password-bundle/src/Model/ResetPasswordRequestTrait.php
@@ -52,7 +52,7 @@
     protected $expiresAt;
 
     /** @return void */
-    protected function initialize(\DateTimeInterface $expiresAt, string $selector, string $hashedToken)
+    protected function initialize(\DateTimeInterface $expiresAt, string $selector, string $hashedToken): void
     {
         $this->requestedAt = Clock::get()->now();
         $this->expiresAt = $expiresAt;
````
which is unrelated and already exists.