### PR TITLE
[interface] add $resetRequestLifetime to generateResetToken() signature

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,11 +31,6 @@ parameters:
 			path: src/ResetPasswordHelper.php
 
 		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$resetRequestLifetime$#"
-			count: 1
-			path: src/ResetPasswordHelperInterface.php
-
-		-
 			message: "#^Property SymfonyCasts\\\\Bundle\\\\ResetPassword\\\\Util\\\\ResetPasswordCleaner\\:\\:\\$repository has no type specified\\.$#"
 			count: 1
 			path: src/Util/ResetPasswordCleaner.php

--- a/src/ResetPasswordHelperInterface.php
+++ b/src/ResetPasswordHelperInterface.php
@@ -28,11 +28,11 @@ interface ResetPasswordHelperInterface
      * and removeResetRequest() can eventually invalidate it by removing it
      * from storage.
      *
-     * @param ?int $resetRequestLifetime Override the default (to be added to interface in 2.0)
+     * @param ?int $resetRequestLifetime Override the default lifetime
      *
      * @throws ResetPasswordExceptionInterface
      */
-    public function generateResetToken(object $user/* , ?int $resetRequestLifetime = null */): ResetPasswordToken;
+    public function generateResetToken(object $user, ?int $resetRequestLifetime = null): ResetPasswordToken;
 
     /**
      * Validate a reset request and fetch the user from persistence.


### PR DESCRIPTION
ResetPasswordHelperInterface::generateResetToken() has always accepted an optional $resetRequestLifetime, but the interface commented out the parameter rather than declaring it, with a note "to be added to interface in 2.0". This means any consumer relying on the interface type-hint (e.g. for static analysis, mocking, or decorating) sees a 1-parameter method while the concrete ResetPasswordHelper takes 2, which PHPStan (and other tools) correctly flag as an arity mismatch.

This exact change already landed on the 2.x branch in #300, but that branch has had no activity since August 2024. Since PHP allows calling a method with more arguments than an interface declares (extra args are simply ignored, not a fatal error) and adding an optional trailing parameter to an interface doesn't break existing implementations, this is safe to land on main without waiting for a 2.0 release.

Also drops the now-stale PHPStan baseline entry for the docblock/signature mismatch this was previously suppressing.